### PR TITLE
Format test output in CI with gotestfmt

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,8 +42,14 @@ jobs:
             - name: Build
               run: go build ./cmd/syncv3
 
+            - name: Set up gotestfmt
+              uses: GoTestTools/gotestfmt-action@v2
+
             - name: Test
-              run: go test -covermode=atomic -coverpkg ./... -p 1 $(go list ./... | grep -v tests-e2e) -coverprofile synccoverage.out
+              run: |
+                set -euo pipefail
+                go test -covermode=atomic -coverpkg ./... -p 1 -v -json $(go list ./... | grep -v tests-e2e) -coverprofile synccoverage.out 2>&1 | tee ./test-integration.log | gotestfmt
+              shell: bash
               env:
                   POSTGRES_HOST: localhost
                   POSTGRES_USER: postgres
@@ -61,6 +67,14 @@ jobs:
                   SYNCV3_DB: user=postgres dbname=syncv3 sslmode=disable password=postgres host=localhost
                   SYNCV3_SERVER: https://matrix-client.matrix.org
                   SYNCV3_SECRET: itsasecret
+
+            - name: Upload test log
+              uses: actions/upload-artifact@v2
+              if: always()
+              with:
+                name: Integration test logs
+                path: ./test-integration.log
+                if-no-files-found: error
     end_to_end:
         runs-on: ubuntu-latest
         services:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,11 @@ on:
     pull_request:
         branches: ["main"]
 
+permissions:
+  packages: read
+  # Note: from https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+  # > If you specify the access for any of these scopes, all of those that are not specified are set to none.
+
 jobs:
     integration:
         runs-on: ubuntu-latest
@@ -44,6 +49,9 @@ jobs:
 
             - name: Set up gotestfmt
               uses: GoTestTools/gotestfmt-action@v2
+              with:
+                # Note: constrained to `packages:read` only at the top of the file
+                token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Test
               run: |
@@ -115,6 +123,9 @@ jobs:
 
             - name: Set up gotestfmt
               uses: GoTestTools/gotestfmt-action@v2
+              with:
+                # Note: constrained to `packages:read` only at the top of the file
+                token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Run end-to-end tests
               run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,12 +112,31 @@ jobs:
                   echo "~/go/bin" >> $GITHUB_PATH
             - name: Build
               run: go build ./cmd/syncv3
+
+            - name: Set up gotestfmt
+              uses: GoTestTools/gotestfmt-action@v2
+
             - name: Run end-to-end tests
-              run: (cd tests-e2e && ./run-tests.sh .)
+              run: |
+                set -euo pipefail
+                ./run-tests.sh -v -json . 2>&1 | tee test-e2e-runner.log | gotestfmt
+              working-directory: tests-e2e
+              shell: bash
               env:
                   SYNCV3_DB: user=postgres dbname=syncv3 sslmode=disable password=postgres host=localhost
                   SYNCV3_SERVER: http://localhost:8008
                   SYNCV3_SECRET: itsasecret
+                  E2E_TEST_SERVER_STDOUT: test-e2e-server.log
+
+            - name: Upload test log
+              uses: actions/upload-artifact@v2
+              if: always()
+              with:
+                name: E2E test logs
+                path: |
+                  ./tests-e2e/test-e2e-runner.log
+                  ./tests-e2e/test-e2e-server.log
+                if-no-files-found: error
     element_web:
         runs-on: ubuntu-latest
         steps:

--- a/tests-e2e/run-tests.sh
+++ b/tests-e2e/run-tests.sh
@@ -4,7 +4,8 @@ export SYNCV3_ADDR='http://localhost:8844'
 export SYNCV3_DEBUG=1
 
 # Run the binary and stop it afterwards.
-../syncv3 &
+# Direct stderr into stdout, and optionally redirect both to a file.
+../syncv3 &> "${E2E_TEST_SERVER_STDOUT:-/dev/stdout}" &
 SYNCV3_PID=$!
 trap "kill $SYNCV3_PID" EXIT
 


### PR DESCRIPTION
This was annoying me on #32.

I sanity checked that the instructions https://github.com/matrix-org/sliding-sync/blob/7ac03c46ca4479b90ca6e712431df7e0e1d36f38/tests-e2e/README.md?plain=1#L18-L29 still work locally, even after the changes I made to `run-tests.sh`.