### PR TITLE
Deal with upcoming GHA deprecations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,10 +37,10 @@ jobs:
                     --health-retries 5
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
 
             - name: Install Go
-              uses: actions/setup-go@v2
+              uses: actions/setup-go@v3
               with:
                   go-version: 1.19
 
@@ -77,7 +77,7 @@ jobs:
                   SYNCV3_SECRET: itsasecret
 
             - name: Upload test log
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               if: always()
               with:
                 name: Integration test logs
@@ -113,7 +113,7 @@ jobs:
                     --health-timeout 5s
                     --health-retries 5
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: "Set Go Version"
               run: |
                   echo "$GOROOT_1_19_X64/bin" >> $GITHUB_PATH
@@ -151,12 +151,12 @@ jobs:
     element_web:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: "Build docker image"
               env:
                 DOCKER_BUILDKIT: 1
               run: docker build -f Dockerfile -t ghcr.io/matrix-org/sliding-sync:ci  .
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
               with:
                 repository: matrix-org/matrix-react-sdk
             - uses: actions/setup-node@v3
@@ -173,7 +173,7 @@ jobs:
               run: yarn build
               working-directory: ./element-web
             - name: "Run cypress tests"
-              uses: cypress-io/github-action@v4.1.1
+              uses: cypress-io/github-action@v5.5.1
               with:
                 browser: chrome
                 start: npx serve -p 8080 ./element-web/webapp

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,7 +140,7 @@ jobs:
                   E2E_TEST_SERVER_STDOUT: test-e2e-server.log
 
             - name: Upload test log
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v3
               if: always()
               with:
                 name: E2E test logs


### PR DESCRIPTION
The point is to get rid of these warnings:

![Screenshot from 2023-03-21 17-21-25](https://user-images.githubusercontent.com/8614563/226692129-6850f4d0-de1f-4e9b-b3da-1c5197311de2.png)


See
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I've done similar in https://github.com/matrix-org/synapse/issues/14203
