### PR TITLE
Implement listening on TLS/HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Using a Docker image:
 ```
 docker run --rm -e "SYNCV3_SERVER=https://matrix-client.matrix.org" -e "SYNCV3_SECRET=$(cat .secret)" -e "SYNCV3_BINDADDR=:8008" -e "SYNCV3_DB=user=$(whoami) dbname=syncv3 sslmode=disable host=host.docker.internal" -p 8008:8008 ghcr.io/matrix-org/sliding-sync:v0.98.0
 ```
+Optionally also set `SYNCV3_TLS_CERT=path/to/cert.pem` and `SYNCV3_TLS_KEY=path/to/key.pem` to listen on HTTPS instead of HTTP.
 
 Then visit http://localhost:8008/client/ (with trailing slash) and paste in the `access_token` for any account on `-server`.
 

--- a/v3.go
+++ b/v3.go
@@ -160,7 +160,7 @@ func RunSyncV3Server(h http.Handler, bindAddr, destV2Server, tlsCert, tlsKey str
 
 	// Block forever
 	var err error
-	if tlsCert != "" {
+	if tlsCert != "" && tlsKey != "" {
 		logger.Info().Msgf("listening TLS on %s", bindAddr)
 		err = http.ListenAndServeTLS(bindAddr, tlsCert, tlsKey, srv)
 	} else {


### PR DESCRIPTION
This uses Go's vanilla ListenAndServeTLS(), and as such none of the normal TLS toggles are available for the user to configure. This provides a basic H2+TLS1.3 with modern cipher experience, which should be good enough for use on the open internet.

```
frebib@frebib-PC ~/sliding-sync> ./syncv3
Sync v3 [0.99.1] ()

Environment var
SYNCV3_SERVER     Required. The destination homeserver to talk to (CS API HTTPS URL) e.g 'https://matrix-client.matrix.org'
SYNCV3_DB         Required. The postgres connection string: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
SYNCV3_SECRET     Required. A secret to use to encrypt access tokens. Must remain the same for the lifetime of the database.
SYNCV3_BINDADDR   Default: 0.0.0.0:8008.  The interface and port to listen on.
SYNCV3_TLS_CERT   Default: unset. Path to a certificate file to serve to HTTPS clients. Specifying this enables TLS on the bound address.
SYNCV3_TLS_KEY    Default: unset. Path to a key file for the certificate. Must be provided along with the certificate file.
SYNCV3_PPROF      Default: unset. The bind addr for pprof debugging e.g ':6060'. If not set, does not listen.
SYNCV3_PROM       Default: unset. The bind addr for Prometheus metrics, which will be accessible at /metrics at this address.
SYNCV3_JAEGER_URL Default: unset. The Jaeger URL to send spans to e.g http://localhost:14268/api/traces - if unset does not send OTLP traces.

SYNCV3_SERVER is not set
SYNCV3_SERVER, SYNCV3_DB, SYNCV3_SECRET, SYNCV3_BINDADDR must be set
```