### PR TITLE
Encourage PR signoff

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+### Pull Request Checklist
+
+- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,10 @@ permissions:
   # > If you specify the access for any of these scopes, all of those that are not specified are set to none.
 
 jobs:
+    check-signoff:
+        if: "github.event_name == 'pull_request'"
+        uses: "matrix-org/backend-meta/.github/workflows/sign-off.yml@v2"
+
     integration:
         runs-on: ubuntu-latest
 


### PR DESCRIPTION
Same as https://github.com/matrix-org/complement/pull/598

Half-Shot put this together, see https://github.com/matrix-org/backend-meta/blob/release/v2/.github/workflows/sign-off.yml for the machinery. Members of matrix-org shouldn't need to explicitly sign-off.