### PR TITLE
List/room granularity for the account data extension

### DIFF
--- a/sync3/extensions/account_data.go
+++ b/sync3/extensions/account_data.go
@@ -77,8 +77,10 @@ func (r *AccountDataRequest) ProcessInitial(ctx context.Context, res *Response, 
 	roomIDs := make([]string, len(extCtx.RoomIDToTimeline))
 	i := 0
 	for roomID := range extCtx.RoomIDToTimeline {
-		roomIDs[i] = roomID
-		i++
+		if r.RoomInScope(roomID, extCtx) {
+			roomIDs[i] = roomID
+			i++
+		}
 	}
 	extRes := &AccountDataResponse{
 		Rooms: make(map[string][]json.RawMessage),

--- a/sync3/extensions/account_data.go
+++ b/sync3/extensions/account_data.go
@@ -45,8 +45,13 @@ func (r *AccountDataRequest) AppendLive(ctx context.Context, res *Response, extC
 	case *caches.AccountDataUpdate:
 		globalMsgs = accountEventsAsJSON(update.AccountData)
 	case *caches.RoomAccountDataUpdate:
-		roomToMsgs[update.RoomID()] = accountEventsAsJSON(update.AccountData)
+		if r.RoomInScope(update.RoomID(), extCtx) {
+			roomToMsgs[update.RoomID()] = accountEventsAsJSON(update.AccountData)
+		}
 	case caches.RoomUpdate:
+		if !r.RoomInScope(update.RoomID(), extCtx) {
+			break
+		}
 		// if this is a room update which is included in the response, send account data for this room
 		if _, exists := extCtx.RoomIDToTimeline[update.RoomID()]; exists {
 			roomAccountData, err := extCtx.Store.AccountDatas(extCtx.UserID, update.RoomID())

--- a/sync3/extensions/typing.go
+++ b/sync3/extensions/typing.go
@@ -53,7 +53,7 @@ func (r *TypingRequest) AppendLive(ctx context.Context, res *Response, extCtx Co
 	}
 
 	// We've found a typing event. Ignore it if the client doesn't want to know about it.
-	if !r.shouldProcessUpdate(roomID, extCtx) {
+	if !r.RoomInScope(roomID, extCtx) {
 		return
 	}
 
@@ -63,33 +63,6 @@ func (r *TypingRequest) AppendLive(ctx context.Context, res *Response, extCtx Co
 		}
 	}
 	res.Typing.Rooms[roomID] = typingEvent
-}
-
-func (r *TypingRequest) shouldProcessUpdate(roomID string, extCtx Context) bool {
-	// If the extension hasn't had its scope configured, process everything.
-	if r.Lists == nil && r.Rooms == nil {
-		return true
-	}
-
-	// If this extension has been explicitly subscribed to this room, process the update.
-	for _, roomInScope := range r.Rooms {
-		if roomInScope == roomID {
-			return true
-		}
-	}
-
-	// If the room belongs to one of the lists that this extension should process, process the update.
-	visibleInLists := extCtx.RoomIDsToLists[roomID]
-	for _, visibleInList := range visibleInLists {
-		for _, shouldProcessList := range r.Lists {
-			if visibleInList == shouldProcessList {
-				return true
-			}
-		}
-	}
-
-	// Otherwise ignore the update.
-	return false
 }
 
 func (r *TypingRequest) ProcessInitial(ctx context.Context, res *Response, extCtx Context) {
@@ -106,7 +79,7 @@ func (r *TypingRequest) ProcessInitial(ctx context.Context, res *Response, extCt
 			continue
 		}
 
-		if !r.shouldProcessUpdate(roomID, extCtx) {
+		if !r.RoomInScope(roomID, extCtx) {
 			continue
 		}
 

--- a/tests-e2e/account_data_test.go
+++ b/tests-e2e/account_data_test.go
@@ -1,0 +1,95 @@
+package syncv3_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/matrix-org/sliding-sync/sync3"
+	"github.com/matrix-org/sliding-sync/sync3/extensions"
+	"github.com/matrix-org/sliding-sync/testutils"
+	"github.com/matrix-org/sliding-sync/testutils/m"
+	"testing"
+)
+
+func TestAccountDataRespectsExtensionScope(t *testing.T) {
+	alice := registerNewUser(t)
+
+	var syncResp *sync3.Response
+
+	// Want at least one test of the initial sync behaviour (which hits `ProcessInitial`)
+	// separate to the incremental sync behaviour (hits `AppendLive`)
+	t.Log("Alice creates rooms 1 and 2.")
+	room1 := alice.CreateRoom(t, map[string]interface{}{"preset": "public_chat", "name": "room 1"})
+	room2 := alice.CreateRoom(t, map[string]interface{}{"preset": "public_chat", "name": "room 2"})
+	t.Logf("room1=%s room2=%s", room1, room2)
+
+	t.Log("Alice uploads account data for both rooms, plus global account data.")
+	globalAccountDataEvent := putGlobalAccountData(
+		t,
+		alice,
+		"com.example.global",
+		map[string]interface{}{"global": "GLOBAL!"},
+	)
+	putRoomAccountData(
+		t,
+		alice,
+		room1,
+		"com.example.room",
+		map[string]interface{}{"room": 1},
+	)
+	putRoomAccountData(
+		t,
+		alice,
+		room2,
+		"com.example.room",
+		map[string]interface{}{"room": 2},
+	)
+
+	t.Log("Alice makes an initial sync request, requesting global account data only.")
+	syncResp = alice.SlidingSync(t, sync3.Request{
+		Extensions: extensions.Request{
+			AccountData: &extensions.AccountDataRequest{
+				Core: extensions.Core{Enabled: &boolTrue, Lists: []string{}, Rooms: []string{}},
+			},
+		},
+		Lists: map[string]sync3.RequestList{
+			"window": {
+				Ranges: sync3.SliceRanges{{0, 20}},
+			},
+		},
+	})
+
+	t.Log("Alice should see her global account data only.")
+	m.MatchResponse(
+		t,
+		syncResp,
+		func(res *sync3.Response) error {
+			for _, msg := range res.Extensions.AccountData.Global {
+				if bytes.Equal(msg, globalAccountDataEvent) {
+					return nil
+				}
+			}
+			return fmt.Errorf("could not find the global account data that Alice PUT earlier")
+		},
+		m.MatchNoRoomAccountData([]string{room1, room2}),
+	)
+}
+
+// putAccountData is a wrapper around SetGlobalAccountData. It returns the account data
+// event as a json.RawMessage, automatically including top-level `type` and `content`
+// fields. This is useful because it can be compared with account data events in a
+// sync response with bytes.Equal.
+func putGlobalAccountData(t *testing.T, client *CSAPI, eventType string, content map[string]interface{}) json.RawMessage {
+	t.Helper()
+	client.SetGlobalAccountData(t, eventType, content)
+	serialised := testutils.NewAccountData(t, eventType, content)
+	return serialised
+}
+
+// putRoomAccountData is like putGlobalAccountData, but for room-specific account data.
+func putRoomAccountData(t *testing.T, client *CSAPI, roomID, eventType string, content map[string]interface{}) json.RawMessage {
+	t.Helper()
+	client.SetRoomAccountData(t, roomID, eventType, content)
+	serialised := testutils.NewAccountData(t, eventType, content)
+	return serialised
+}

--- a/testutils/m/match.go
+++ b/testutils/m/match.go
@@ -511,6 +511,20 @@ func MatchReceipts(roomID string, wantReceipts []Receipt) RespMatcher {
 	}
 }
 
+// MatchAccountData builds a matcher which asserts that the account data in a sync
+// response /exactly/ matches the given `globals` and `rooms`, up to ordering.
+//
+// - If there is no account data extension in the response, the matche fails.
+// - If globals is non-nil:
+//   - if globals is not equal to the global account data, the match fails.
+//     Equality is determined using EqualAnyOrder.
+//
+// - If rooms is non-nil:
+//   - If the set of given rooms differs from the set of rooms present in the account
+//     data response, the match fails.
+//   - If a given room's account data events are not equal to its account data events
+//     in the sync response, the match fails. Again, equality is determined using
+//     EqualAnyOrder.
 func MatchAccountData(globals []json.RawMessage, rooms map[string][]json.RawMessage) RespMatcher {
 	return func(res *sync3.Response) error {
 		if res.Extensions.AccountData == nil {
@@ -539,7 +553,8 @@ func MatchAccountData(globals []json.RawMessage, rooms map[string][]json.RawMess
 	}
 }
 
-// MatchHasGlobalAccountData works well enough
+// MatchHasGlobalAccountData builds a matcher which asserts that the given event is
+// present in a global account data response.
 func MatchHasGlobalAccountData(want json.RawMessage) RespMatcher {
 	return func(res *sync3.Response) error {
 		for _, msg := range res.Extensions.AccountData.Global {

--- a/testutils/m/match.go
+++ b/testutils/m/match.go
@@ -539,6 +539,34 @@ func MatchAccountData(globals []json.RawMessage, rooms map[string][]json.RawMess
 	}
 }
 
+// MatchHasGlobalAccountData works well enough
+func MatchHasGlobalAccountData(want json.RawMessage) RespMatcher {
+	return func(res *sync3.Response) error {
+		for _, msg := range res.Extensions.AccountData.Global {
+			if bytes.Equal(msg, want) {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("could not find %s in global account data", want)
+	}
+}
+
+// MatchNoGlobalAccountData builds a matcher which asserts that no global account data
+// is present in a sync response.
+func MatchNoGlobalAccountData() RespMatcher {
+	return func(res *sync3.Response) error {
+		if res.Extensions.AccountData == nil {
+			return nil
+		}
+		accountDataEvents := res.Extensions.AccountData.Global
+		if len(accountDataEvents) > 0 {
+			return fmt.Errorf("MatchNoGlobalAccountData: got %d account data events, but expected none", len(accountDataEvents))
+		}
+		return nil
+	}
+}
+
 // MatchNoRoomAccountData builds a matcher which asserts that none of the given roomIDs
 // have room account data in a sync response.
 func MatchNoRoomAccountData(roomIDs []string) RespMatcher {

--- a/testutils/m/match.go
+++ b/testutils/m/match.go
@@ -539,6 +539,21 @@ func MatchAccountData(globals []json.RawMessage, rooms map[string][]json.RawMess
 	}
 }
 
+// MatchNoRoomAccountData builds a matcher which asserts that none of the given roomIDs
+// have room account data in a sync response.
+func MatchNoRoomAccountData(roomIDs []string) RespMatcher {
+	return func(res *sync3.Response) error {
+		for _, roomID := range roomIDs {
+			// quick and dirty: complain the first time we see something we shouldn't
+			roomData := res.Extensions.AccountData.Rooms[roomID]
+			if roomData != nil {
+				return fmt.Errorf("MatchNoRoomAccountData: got account data for %s, but expected it to be missing", roomID)
+			}
+		}
+		return nil
+	}
+}
+
 func CheckList(listKey string, res sync3.ResponseList, matchers ...ListMatcher) error {
 	for _, m := range matchers {
 		if err := m(res); err != nil {

--- a/testutils/m/match.go
+++ b/testutils/m/match.go
@@ -557,6 +557,9 @@ func MatchAccountData(globals []json.RawMessage, rooms map[string][]json.RawMess
 // present in a global account data response.
 func MatchHasGlobalAccountData(want json.RawMessage) RespMatcher {
 	return func(res *sync3.Response) error {
+		if res.Extensions.AccountData == nil {
+			return fmt.Errorf("No account data section in sync response")
+		}
 		for _, msg := range res.Extensions.AccountData.Global {
 			if bytes.Equal(msg, want) {
 				return nil
@@ -586,6 +589,9 @@ func MatchNoGlobalAccountData() RespMatcher {
 // have room account data in a sync response.
 func MatchNoRoomAccountData(roomIDs []string) RespMatcher {
 	return func(res *sync3.Response) error {
+		if res.Extensions.AccountData == nil {
+			return nil
+		}
 		for _, roomID := range roomIDs {
 			// quick and dirty: complain the first time we see something we shouldn't
 			roomData := res.Extensions.AccountData.Rooms[roomID]


### PR DESCRIPTION
More of #41.

This was easier than I expected; the hardest part was writing the test.

I'd intended for one of the tests I wrote in #50 to demonstrate that I had correctly changed `AppendLive`, but I think the test I wrote simply doesn't do that.

I think what I've got here really does exercise the `AppendLive` path---but it does so as an e2e test and is probably going to be brittle (e.g. there are timeouts). Maybe this would be better suited for`extensions/account_data_test.go`?