### PR TITLE
Exact SYNC and INVALIDATE ranges

### DIFF
--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -242,6 +242,11 @@ func (s *ConnState) onIncomingListRequest(ctx context.Context, builder *RoomsBui
 			logger.Trace().Interface("range", prevRange).Msg("INVALIDATEing because sort/filter ops have changed")
 			allRoomIDs := roomList.RoomIDs()
 			for _, r := range prevRange {
+				if r[0] >= roomList.Len() {
+					// This range will not have been echoed to the client because it is outside
+					// the total length of the room list; do not try to invalidate it.
+					continue
+				}
 				responseOperations = append(responseOperations, &sync3.ResponseOpRange{
 					Operation: sync3.OpInvalidate,
 					Range:     clampSliceRangeToListSize(r, int64(len(allRoomIDs))),
@@ -265,6 +270,11 @@ func (s *ConnState) onIncomingListRequest(ctx context.Context, builder *RoomsBui
 		logger.Trace().Interface("range", removedRanges).Msg("INVALIDATEing because ranges were removed")
 	}
 	for i := range removedRanges {
+		if removedRanges[i][0] >= (roomList.Len()) {
+			// This range will not have been echoed to the client because it is outside
+			// the total length of the room list; do not try to invalidate it.
+			continue
+		}
 		responseOperations = append(responseOperations, &sync3.ResponseOpRange{
 			Operation: sync3.OpInvalidate,
 			Range:     clampSliceRangeToListSize(removedRanges[i], roomList.Len()),

--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -566,13 +566,13 @@ func (s *ConnState) OnRoomUpdate(ctx context.Context, up caches.RoomUpdate) {
 // does not overlap the full room list, return nil. Otherwise, return the intersection
 // of r with the full room list.
 func clampSliceRangeToListSize(r [2]int64, totalRooms int64) []int64 {
-	lastIndexInRoom := totalRooms - 1
-	if r[0] > lastIndexInRoom {
+	lastIndexWithRoom := totalRooms - 1
+	if r[0] > lastIndexWithRoom {
 		return nil
-	} else if r[1] <= lastIndexInRoom {
+	} else if r[1] <= lastIndexWithRoom {
 		return r[:]
 	} else {
-		return []int64{r[0], lastIndexInRoom}
+		return []int64{r[0], lastIndexWithRoom}
 	}
 
 }

--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -557,7 +557,7 @@ func (s *ConnState) OnRoomUpdate(ctx context.Context, up caches.RoomUpdate) {
 	}
 }
 
-// clampSliceRangeToListSize helps us send client-friend SYNC and INVALIDATE ranges.
+// clampSliceRangeToListSize helps us to send client-friendly SYNC and INVALIDATE ranges.
 //
 // Suppose the client asks for a window on positions [10, 19]. If the list
 // has exactly 12 rooms, the window will see 3: those at positions 10, 11

--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -269,11 +269,13 @@ func (s *ConnState) onIncomingListRequest(ctx context.Context, builder *RoomsBui
 		logger.Trace().Interface("range", removedRanges).Msg("INVALIDATEing because ranges were removed")
 	}
 	for i := range removedRanges {
+		clamped := clampSliceRangeToListSize(removedRanges[i], roomList.Len())
+		if clamped == nil {
+			continue
+		}
 		responseOperations = append(responseOperations, &sync3.ResponseOpRange{
 			Operation: sync3.OpInvalidate,
-			// we shouldn't need to clamp this range: we are removing concrete rooms
-			// whose position is in bounds.
-			Range: removedRanges[i][:],
+			Range:     clamped,
 		})
 	}
 

--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -242,7 +242,7 @@ func (s *ConnState) onIncomingListRequest(ctx context.Context, builder *RoomsBui
 			logger.Trace().Interface("range", prevRange).Msg("INVALIDATEing because sort/filter ops have changed")
 			allRoomIDs := roomList.RoomIDs()
 			for _, r := range prevRange {
-				clamped := clampSliceRangeToListSize(r, len(allRoomIDs))
+				clamped := clampSliceRangeToListSize(r, int64(len(allRoomIDs)))
 				if clamped == nil {
 					continue
 				}
@@ -292,7 +292,7 @@ func (s *ConnState) onIncomingListRequest(ctx context.Context, builder *RoomsBui
 		// the builder will populate this with the right room data
 		builder.AddRoomsToSubscription(subID, roomIDs)
 
-		clamped := clampSliceRangeToListSize(addedRanges[i], len(roomIDs))
+		clamped := clampSliceRangeToListSize(addedRanges[i], roomList.Len())
 		if clamped == nil {
 			continue
 		}
@@ -565,8 +565,8 @@ func (s *ConnState) OnRoomUpdate(ctx context.Context, up caches.RoomUpdate) {
 // The "full" room list occupies positions [0, totalRooms - 1]. If the given range r
 // does not overlap the full room list, return nil. Otherwise, return the intersection
 // of r with the full room list.
-func clampSliceRangeToListSize(r [2]int64, totalRooms int) []int64 {
-	lastIndexInRoom := int64(totalRooms) - 1
+func clampSliceRangeToListSize(r [2]int64, totalRooms int64) []int64 {
+	lastIndexInRoom := totalRooms - 1
 	if r[0] > lastIndexInRoom {
 		return nil
 	} else if r[1] <= lastIndexInRoom {

--- a/sync3/handler/connstate_test.go
+++ b/sync3/handler/connstate_test.go
@@ -143,7 +143,7 @@ func TestConnStateInitial(t *testing.T) {
 				Ops: []sync3.ResponseOp{
 					&sync3.ResponseOpRange{
 						Operation: "SYNC",
-						Range:     []int64{0, 2},
+						Range:     [2]int64{0, 2},
 						RoomIDs: []string{
 							roomB.RoomID, roomC.RoomID, roomA.RoomID,
 						},
@@ -289,7 +289,7 @@ func TestConnStateMultipleRanges(t *testing.T) {
 				Ops: []sync3.ResponseOp{
 					&sync3.ResponseOpRange{
 						Operation: "SYNC",
-						Range:     []int64{0, 2},
+						Range:     [2]int64{0, 2},
 						RoomIDs:   []string{roomIDs[0], roomIDs[1], roomIDs[2]},
 					},
 				},
@@ -315,7 +315,7 @@ func TestConnStateMultipleRanges(t *testing.T) {
 				Ops: []sync3.ResponseOp{
 					&sync3.ResponseOpRange{
 						Operation: "SYNC",
-						Range:     []int64{4, 6},
+						Range:     [2]int64{4, 6},
 						RoomIDs:   []string{roomIDs[4], roomIDs[5], roomIDs[6]},
 					},
 				},
@@ -465,7 +465,7 @@ func TestBumpToOutsideRange(t *testing.T) {
 				Ops: []sync3.ResponseOp{
 					&sync3.ResponseOpRange{
 						Operation: "SYNC",
-						Range:     []int64{0, 1},
+						Range:     [2]int64{0, 1},
 						RoomIDs: []string{
 							roomA.RoomID, roomB.RoomID,
 						},
@@ -578,7 +578,7 @@ func TestConnStateRoomSubscriptions(t *testing.T) {
 				Ops: []sync3.ResponseOp{
 					&sync3.ResponseOpRange{
 						Operation: "SYNC",
-						Range:     []int64{0, 1},
+						Range:     [2]int64{0, 1},
 						RoomIDs: []string{
 							roomA.RoomID, roomB.RoomID,
 						},

--- a/sync3/handler/connstate_test.go
+++ b/sync3/handler/connstate_test.go
@@ -143,7 +143,7 @@ func TestConnStateInitial(t *testing.T) {
 				Ops: []sync3.ResponseOp{
 					&sync3.ResponseOpRange{
 						Operation: "SYNC",
-						Range:     []int64{0, 9},
+						Range:     []int64{0, 2},
 						RoomIDs: []string{
 							roomB.RoomID, roomC.RoomID, roomA.RoomID,
 						},

--- a/sync3/response.go
+++ b/sync3/response.go
@@ -114,7 +114,7 @@ type ResponseOp interface {
 
 type ResponseOpRange struct {
 	Operation string   `json:"op"`
-	Range     []int64  `json:"range,omitempty"`
+	Range     [2]int64 `json:"range,omitempty"`
 	RoomIDs   []string `json:"room_ids,omitempty"`
 }
 

--- a/tests-e2e/client_test.go
+++ b/tests-e2e/client_test.go
@@ -587,6 +587,14 @@ func (c *CSAPI) SlidingSyncUntilEventID(t *testing.T, pos string, roomID string,
 
 func (c *CSAPI) SlidingSyncUntilMembership(t *testing.T, pos string, roomID string, target *CSAPI, membership string) (res *sync3.Response) {
 	t.Helper()
+	content := map[string]interface{}{
+		"membership": membership,
+	}
+
+	if membership == "join" {
+		content["displayname"] = target.Localpart
+	}
+
 	return c.SlidingSyncUntilEvent(t, pos, sync3.Request{
 		RoomSubscriptions: map[string]sync3.RoomSubscription{
 			roomID: {
@@ -596,10 +604,7 @@ func (c *CSAPI) SlidingSyncUntilMembership(t *testing.T, pos string, roomID stri
 	}, roomID, Event{
 		Type:     "m.room.member",
 		StateKey: &target.UserID,
-		Content: map[string]interface{}{
-			"displayname": target.Localpart,
-			"membership":  membership,
-		},
+		Content:  content,
 	})
 }
 

--- a/tests-e2e/client_test.go
+++ b/tests-e2e/client_test.go
@@ -591,7 +591,7 @@ func (c *CSAPI) SlidingSyncUntilMembership(t *testing.T, pos string, roomID stri
 		"membership": membership,
 	}
 
-	if membership == "join" {
+	if membership == "join" || membership == "invite" {
 		content["displayname"] = target.Localpart
 	}
 

--- a/tests-e2e/lists_test.go
+++ b/tests-e2e/lists_test.go
@@ -750,7 +750,7 @@ func TestShrinkRange(t *testing.T) {
 		},
 	})
 	m.MatchResponse(t, res, m.MatchList("a", m.MatchV3Count(10), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 20, roomIDs),
+		m.MatchV3SyncOp(0, 9, roomIDs),
 	)))
 	// now shrink the window on both ends
 	res = alice.SlidingSync(t, sync3.Request{
@@ -762,7 +762,7 @@ func TestShrinkRange(t *testing.T) {
 	}, WithPos(res.Pos))
 	m.MatchResponse(t, res, m.MatchList("a", m.MatchV3Count(10), m.MatchV3Ops(
 		m.MatchV3InvalidateOp(0, 1),
-		m.MatchV3InvalidateOp(7, 20),
+		m.MatchV3InvalidateOp(7, 9),
 	)))
 }
 

--- a/tests-e2e/lists_test.go
+++ b/tests-e2e/lists_test.go
@@ -726,8 +726,8 @@ func TestChangeSortOrder(t *testing.T) {
 	}
 
 	m.MatchResponse(t, res, m.MatchList("a", m.MatchV3Count(4), m.MatchV3Ops(
-		m.MatchV3InvalidateOp(0, 20),
-		m.MatchV3SyncOp(0, 20, []string{gotNameToIDs["Apple"], gotNameToIDs["Kiwi"], gotNameToIDs["Lemon"], gotNameToIDs["Orange"]}),
+		m.MatchV3InvalidateOp(0, 3),
+		m.MatchV3SyncOp(0, 3, []string{gotNameToIDs["Apple"], gotNameToIDs["Kiwi"], gotNameToIDs["Lemon"], gotNameToIDs["Orange"]}),
 	)))
 }
 
@@ -786,7 +786,7 @@ func TestExpandRange(t *testing.T) {
 		},
 	})
 	m.MatchResponse(t, res, m.MatchList("a", m.MatchV3Count(10), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 10, roomIDs),
+		m.MatchV3SyncOp(0, 9, roomIDs),
 	)))
 	// now expand the window
 	res = alice.SlidingSync(t, sync3.Request{
@@ -834,10 +834,10 @@ func TestMultipleSameList(t *testing.T) {
 	})
 	m.MatchResponse(t, res,
 		m.MatchList("1", m.MatchV3Count(16), m.MatchV3Ops(
-			m.MatchV3SyncOp(0, 20, roomIDs, false),
+			m.MatchV3SyncOp(0, 15, roomIDs, false),
 		)),
 		m.MatchList("2", m.MatchV3Count(16), m.MatchV3Ops(
-			m.MatchV3SyncOp(0, 16, roomIDs, false),
+			m.MatchV3SyncOp(0, 15, roomIDs, false),
 		)),
 	)
 	// now change both list ranges in a valid but strange way, and get back bad responses
@@ -923,7 +923,7 @@ func TestBumpEventTypesHandling(t *testing.T) {
 	matchRoom1ThenRoom2 := m.MatchList("room_list",
 		m.MatchV3Count(2),
 		m.MatchV3Ops(
-			m.MatchV3SyncOp(0, 20, []string{room1, room2}, false),
+			m.MatchV3SyncOp(0, 1, []string{room1, room2}, false),
 		))
 	m.MatchResponse(t, aliceRes, matchRoom1ThenRoom2)
 

--- a/tests-e2e/lists_test.go
+++ b/tests-e2e/lists_test.go
@@ -851,7 +851,6 @@ func TestMultipleSameList(t *testing.T) {
 	m.MatchResponse(t, res,
 		m.MatchList("1", m.MatchV3Count(16), m.MatchV3Ops(
 			m.MatchV3InvalidateOp(0, 1),
-			m.MatchV3InvalidateOp(16, 20),
 		)),
 		m.MatchList("2", m.MatchV3Count(16), m.MatchV3Ops()),
 	)

--- a/tests-e2e/membership_transitions_test.go
+++ b/tests-e2e/membership_transitions_test.go
@@ -58,7 +58,7 @@ func TestRoomStateTransitions(t *testing.T) {
 		},
 	})
 	m.MatchResponse(t, bobRes, m.MatchList("a", m.MatchV3Count(2), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 100, []string{inviteRoomID, joinRoomID}),
+		m.MatchV3SyncOp(0, 1, []string{inviteRoomID, joinRoomID}),
 	)), m.MatchRoomSubscriptions(map[string][]m.RoomMatcher{
 		inviteRoomID: {
 			m.MatchRoomHighlightCount(1),
@@ -132,7 +132,7 @@ func TestInviteRejection(t *testing.T) {
 		},
 	})
 	m.MatchResponse(t, res, m.MatchList("a", m.MatchV3Count(1), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 20, []string{firstInviteRoomID}),
+		m.MatchV3SyncOp(0, 1, []string{firstInviteRoomID}),
 	)), m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
 		firstInviteRoomID: {
 			m.MatchRoomInitial(true),
@@ -238,7 +238,7 @@ func TestInviteAcceptance(t *testing.T) {
 		},
 	})
 	m.MatchResponse(t, res, m.MatchList("a", m.MatchV3Count(1), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 20, []string{firstInviteRoomID}),
+		m.MatchV3SyncOp(0, 0, []string{firstInviteRoomID}),
 	)), m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
 		firstInviteRoomID: {
 			m.MatchRoomInitial(true),
@@ -342,7 +342,7 @@ func TestMemberCounts(t *testing.T) {
 		},
 	})
 	m.MatchResponse(t, res, m.MatchList("a", m.MatchV3Count(2), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 20, []string{firstRoomID, secondRoomID}, true),
+		m.MatchV3SyncOp(0, 1, []string{firstRoomID, secondRoomID}, true),
 	)), m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
 		firstRoomID: {
 			m.MatchRoomInitial(true),

--- a/tests-e2e/membership_transitions_test.go
+++ b/tests-e2e/membership_transitions_test.go
@@ -132,7 +132,7 @@ func TestInviteRejection(t *testing.T) {
 		},
 	})
 	m.MatchResponse(t, res, m.MatchList("a", m.MatchV3Count(1), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 1, []string{firstInviteRoomID}),
+		m.MatchV3SyncOp(0, 0, []string{firstInviteRoomID}),
 	)), m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
 		firstInviteRoomID: {
 			m.MatchRoomInitial(true),

--- a/tests-e2e/security_test.go
+++ b/tests-e2e/security_test.go
@@ -47,7 +47,7 @@ func TestSecurityLiveStreamEventLeftLeak(t *testing.T) {
 			}},
 	})
 	m.MatchResponse(t, aliceRes, m.MatchList("a", m.MatchV3Count(1), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 10, []string{roomID}),
+		m.MatchV3SyncOp(0, 0, []string{roomID}),
 	)))
 	eveRes := eve.SlidingSync(t, sync3.Request{
 		Lists: map[string]sync3.RequestList{
@@ -58,7 +58,7 @@ func TestSecurityLiveStreamEventLeftLeak(t *testing.T) {
 			}},
 	})
 	m.MatchResponse(t, eveRes, m.MatchList("a", m.MatchV3Count(1), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 10, []string{roomID}),
+		m.MatchV3SyncOp(0, 0, []string{roomID}),
 	)))
 
 	// kick Eve
@@ -193,7 +193,7 @@ func TestSecurityRoomSubscriptionLeak(t *testing.T) {
 	})
 	// Assert that Eve doesn't see anything
 	m.MatchResponse(t, eveRes, m.MatchList("a", m.MatchV3Count(1), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 10, []string{eveUnrelatedRoomID}),
+		m.MatchV3SyncOp(0, 0, []string{eveUnrelatedRoomID}),
 	)), m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
 		eveUnrelatedRoomID: {},
 	}))

--- a/tests-e2e/spaces_test.go
+++ b/tests-e2e/spaces_test.go
@@ -95,7 +95,7 @@ func TestSpacesFilter(t *testing.T) {
 		t.Logf("requesting initial rooms in spaces %v expecting %v", spaces, wantRoomIDs)
 		return doSpacesListRequest(spaces, nil, m.MatchV3Count(len(wantRoomIDs)), m.MatchV3Ops(
 			m.MatchV3SyncOp(
-				0, 20, wantRoomIDs, true,
+				0, int64(len(wantRoomIDs))-1, wantRoomIDs, true,
 			),
 		))
 	}
@@ -154,8 +154,8 @@ func TestSpacesFilter(t *testing.T) {
 	// now completely change the space filter and ensure we see the right rooms
 	doSpacesListRequest([]string{parentD}, &res.Pos,
 		m.MatchV3Count(2), m.MatchV3Ops(
-			m.MatchV3InvalidateOp(0, 20),
-			m.MatchV3SyncOp(0, 20, []string{roomF, roomE}, true),
+			m.MatchV3InvalidateOp(0, 1),
+			m.MatchV3SyncOp(0, 1, []string{roomF, roomE}, true),
 		),
 	)
 }

--- a/tests-e2e/tombstone_test.go
+++ b/tests-e2e/tombstone_test.go
@@ -99,7 +99,7 @@ func TestIncludeOldRooms(t *testing.T) {
 		},
 	})
 	m.MatchResponse(t, res, m.MatchList("a", m.MatchV3Count(1), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 2, []string{newRoomID}),
+		m.MatchV3SyncOp(0, 0, []string{newRoomID}),
 	)), m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
 		newRoomID: {
 			MatchRoomRequiredState([]Event{

--- a/tests-e2e/tombstone_test.go
+++ b/tests-e2e/tombstone_test.go
@@ -294,7 +294,7 @@ func TestIncludeOldRoomsSubscriptionUnion(t *testing.T) {
 		},
 	})
 	m.MatchResponse(t, res, m.MatchList("a", m.MatchV3Count(1), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 1, []string{roomB}),
+		m.MatchV3SyncOp(0, 0, []string{roomB}),
 	)), m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
 		roomA: {
 			MatchRoomRequiredState([]Event{

--- a/tests-e2e/tombstone_test.go
+++ b/tests-e2e/tombstone_test.go
@@ -136,7 +136,7 @@ func TestIncludeOldRooms(t *testing.T) {
 		},
 	})
 	m.MatchResponse(t, res, m.MatchList("a", m.MatchV3Count(1), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 2, []string{newRoomID}),
+		m.MatchV3SyncOp(0, 0, []string{newRoomID}),
 	)), m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
 		newRoomID: {
 			MatchRoomRequiredState([]Event{

--- a/tests-e2e/tombstone_test.go
+++ b/tests-e2e/tombstone_test.go
@@ -27,7 +27,7 @@ func TestIncludeOldRooms(t *testing.T) {
 		},
 	})
 	m.MatchResponse(t, res, m.MatchList("a", m.MatchV3Count(1), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 1, []string{roomID}),
+		m.MatchV3SyncOp(0, 0, []string{roomID}),
 	)))
 	newRoomID := upgradeRoom(t, client, roomID)
 	t.Logf("old %s new %s", roomID, newRoomID)

--- a/tests-integration/connection_test.go
+++ b/tests-integration/connection_test.go
@@ -79,7 +79,7 @@ func TestMultipleConnsAtStartup(t *testing.T) {
 		}},
 	})
 	m.MatchResponse(t, res, m.MatchList("a", m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 10, []string{roomID}),
+		m.MatchV3SyncOp(0, 0, []string{roomID}),
 	)))
 }
 
@@ -393,7 +393,7 @@ func TestTxnIDResponseBuffering(t *testing.T) {
 		}},
 	})
 	m.MatchResponse(t, res, m.MatchTxnID("c"), m.MatchList("a", m.MatchV3Count(1), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 10, []string{roomC}),
+		m.MatchV3SyncOp(0, 0, []string{roomC}),
 	)))
 	// Send a request with pos=1 to filter for room_name_like = A . Discard the response.
 	v3.mustDoV3RequestWithPos(t, aliceToken, res.Pos, sync3.Request{
@@ -430,8 +430,8 @@ func TestTxnIDResponseBuffering(t *testing.T) {
 	})
 	// this response should be the one for A
 	m.MatchResponse(t, res, m.MatchTxnID("a"), m.MatchList("a", m.MatchV3Count(1), m.MatchV3Ops(
-		m.MatchV3InvalidateOp(0, 10),
-		m.MatchV3SyncOp(0, 10, []string{roomA}),
+		m.MatchV3InvalidateOp(0, 0),
+		m.MatchV3SyncOp(0, 0, []string{roomA}),
 	)))
 
 	// poll again
@@ -439,8 +439,8 @@ func TestTxnIDResponseBuffering(t *testing.T) {
 
 	// now we get the response for B
 	m.MatchResponse(t, res, m.MatchTxnID("b"), m.MatchList("a", m.MatchV3Count(1), m.MatchV3Ops(
-		m.MatchV3InvalidateOp(0, 10),
-		m.MatchV3SyncOp(0, 10, []string{roomB}),
+		m.MatchV3InvalidateOp(0, 0),
+		m.MatchV3SyncOp(0, 0, []string{roomB}),
 	)))
 }
 

--- a/tests-integration/filters_test.go
+++ b/tests-integration/filters_test.go
@@ -54,13 +54,14 @@ func TestFiltersEncryption(t *testing.T) {
 			"enc": {
 				m.MatchV3Count(1),
 				m.MatchV3Ops(
-					m.MatchV3SyncOp(0, 1, []string{encryptedRoomID}),
+					m.MatchV3SyncOp(0, 0, []string{encryptedRoomID}),
 				),
 			},
 			"noenc": {
 				m.MatchV3Count(1),
 				m.MatchV3Ops(
-					m.MatchV3SyncOp(0, 1, []string{unencryptedRoomID}),
+					// Note: expect position 0 here---this is a separate list
+					m.MatchV3SyncOp(0, 0, []string{unencryptedRoomID}),
 				),
 			},
 		},
@@ -186,7 +187,7 @@ func TestFiltersInvite(t *testing.T) {
 			"inv": {
 				m.MatchV3Count(1),
 				m.MatchV3Ops(
-					m.MatchV3SyncOp(0, 20, []string{roomID}),
+					m.MatchV3SyncOp(0, 0, []string{roomID}),
 				),
 			},
 			"noinv": {
@@ -286,7 +287,7 @@ func TestFiltersRoomName(t *testing.T) {
 	m.MatchResponse(t, res, m.MatchList("a",
 		m.MatchV3Count(5),
 		m.MatchV3Ops(
-			m.MatchV3SyncOp(0, 20, []string{
+			m.MatchV3SyncOp(0, 4, []string{
 				ridApple, ridPear, ridOrange, ridPineapple, ridBanana,
 			}, true),
 		),
@@ -308,8 +309,8 @@ func TestFiltersRoomName(t *testing.T) {
 	m.MatchResponse(t, res, m.MatchList("a",
 		m.MatchV3Count(2),
 		m.MatchV3Ops(
-			m.MatchV3InvalidateOp(0, 20),
-			m.MatchV3SyncOp(0, 20, []string{
+			m.MatchV3InvalidateOp(0, 4),
+			m.MatchV3SyncOp(0, 1, []string{
 				ridApple, ridPineapple,
 			}, true),
 		),
@@ -398,22 +399,22 @@ func TestFiltersRoomTypes(t *testing.T) {
 	})
 	m.MatchResponse(t, res, m.MatchLists(map[string][]m.ListMatcher{
 		"a": {
-			m.MatchV3Count(1), m.MatchV3Ops(m.MatchV3SyncOp(0, 20, []string{spaceRoomID})),
+			m.MatchV3Count(1), m.MatchV3Ops(m.MatchV3SyncOp(0, 0, []string{spaceRoomID})),
 		},
 		"b": {
-			m.MatchV3Count(1), m.MatchV3Ops(m.MatchV3SyncOp(0, 20, []string{roomID})),
+			m.MatchV3Count(1), m.MatchV3Ops(m.MatchV3SyncOp(0, 0, []string{roomID})),
 		},
 		"c": {
-			m.MatchV3Count(2), m.MatchV3Ops(m.MatchV3SyncOp(0, 20, []string{roomID, otherRoomID}, true)),
+			m.MatchV3Count(2), m.MatchV3Ops(m.MatchV3SyncOp(0, 1, []string{roomID, otherRoomID}, true)),
 		},
 		"d": {
-			m.MatchV3Count(1), m.MatchV3Ops(m.MatchV3SyncOp(0, 20, []string{otherRoomID})),
+			m.MatchV3Count(1), m.MatchV3Ops(m.MatchV3SyncOp(0, 0, []string{otherRoomID})),
 		},
 		"e": {
 			m.MatchV3Count(0),
 		},
 		"f": {
-			m.MatchV3Count(3), m.MatchV3Ops(m.MatchV3SyncOp(0, 20, []string{roomID, otherRoomID, spaceRoomID}, true)),
+			m.MatchV3Count(3), m.MatchV3Ops(m.MatchV3SyncOp(0, 2, []string{roomID, otherRoomID, spaceRoomID}, true)),
 		},
 	}))
 }
@@ -486,11 +487,11 @@ func TestFiltersTags(t *testing.T) {
 		},
 	})
 	m.MatchResponse(t, res, m.MatchList("fav", m.MatchV3Count(3), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 20, []string{fav1RoomID, fav2RoomID, favAndLowRoomID}, true),
+		m.MatchV3SyncOp(0, 2, []string{fav1RoomID, fav2RoomID, favAndLowRoomID}, true),
 	)), m.MatchList("lp", m.MatchV3Count(3), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 20, []string{low1RoomID, low2RoomID, favAndLowRoomID}, true),
+		m.MatchV3SyncOp(0, 2, []string{low1RoomID, low2RoomID, favAndLowRoomID}, true),
 	)), m.MatchList("favlp", m.MatchV3Count(5), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 20, []string{fav1RoomID, fav2RoomID, favAndLowRoomID, low1RoomID, low2RoomID}, true),
+		m.MatchV3SyncOp(0, 4, []string{fav1RoomID, fav2RoomID, favAndLowRoomID, low1RoomID, low2RoomID}, true),
 	)))
 
 	// first bump the fav1 room
@@ -555,9 +556,9 @@ func TestFiltersTags(t *testing.T) {
 		},
 	})
 	m.MatchResponse(t, res, m.MatchList("fav", m.MatchV3Count(2), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 20, []string{fav2RoomID, favAndLowRoomID}, true),
+		m.MatchV3SyncOp(0, 1, []string{fav2RoomID, favAndLowRoomID}, true),
 	)), m.MatchList("nofav", m.MatchV3Count(3), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 20, []string{low1RoomID, low2RoomID, fav1RoomID}, true),
+		m.MatchV3SyncOp(0, 2, []string{low1RoomID, low2RoomID, fav1RoomID}, true),
 	)))
 
 	// remove a fav, it should move to the other list

--- a/tests-integration/invite_test.go
+++ b/tests-integration/invite_test.go
@@ -52,7 +52,7 @@ func TestStuckInvites(t *testing.T) {
 		},
 	})
 	m.MatchResponse(t, res, m.MatchList("a", m.MatchV3Count(1), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 10, []string{preSyncInviteRoomID}),
+		m.MatchV3SyncOp(0, 0, []string{preSyncInviteRoomID}),
 	)))
 
 	// live stream invite

--- a/tests-integration/lists_test.go
+++ b/tests-integration/lists_test.go
@@ -129,7 +129,7 @@ func TestUnreadCountMisordering(t *testing.T) {
 		},
 	})
 	m.MatchResponse(t, res, m.MatchList("a", m.MatchV3Count(3), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 5, []string{roomA, roomB, roomC}),
+		m.MatchV3SyncOp(0, 2, []string{roomA, roomB, roomC}),
 	))) // A,B,C SYNC
 
 	// Then send a new event in C -> [A,C,B]   DELETE 2, INSERT 1 C

--- a/tests-integration/room_names_test.go
+++ b/tests-integration/room_names_test.go
@@ -21,7 +21,7 @@ func TestRoomNames(t *testing.T) {
 	defer v2.close()
 	defer v3.close()
 	bob := "@TestRoomNames_bob:localhost"
-	// make 5 rooms, last room is most recent, and send A,B,C into each room
+	// make 4 rooms, last room is most recent, and send A,B,C into each room
 	latestTimestamp := time.Now()
 	allRooms := []roomEvents{
 		{
@@ -113,7 +113,7 @@ func TestRoomNames(t *testing.T) {
 			Lists: map[string]sync3.RequestList{
 				"a": {
 					Ranges: sync3.SliceRanges{
-						[2]int64{0, int64(len(allRooms) - 1)}, // all rooms
+						[2]int64{0, (int64(len(allRooms)) - 1)}, // all rooms
 					},
 					Filters: &sync3.RequestFilters{
 						RoomNameFilter: searchTerm,
@@ -129,7 +129,7 @@ func TestRoomNames(t *testing.T) {
 			}
 		}
 		m.MatchResponse(t, res, m.MatchList("a", m.MatchV3Count(len(wantRooms)), m.MatchV3Ops(
-			m.MatchV3SyncOp(0, int64(len(allRooms)-1), wantRoomIDs),
+			m.MatchV3SyncOp(0, int64(len(wantRooms)-1), wantRoomIDs),
 		)), m.MatchRoomSubscriptions(matchers))
 	}
 	// case-insensitive matching

--- a/tests-integration/timeline_test.go
+++ b/tests-integration/timeline_test.go
@@ -358,7 +358,7 @@ func TestInitialFlag(t *testing.T) {
 		}},
 	})
 	m.MatchResponse(t, res, m.MatchList("a", m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 10, []string{roomID}),
+		m.MatchV3SyncOp(0, 0, []string{roomID}),
 	)), m.MatchRoomSubscription(roomID, m.MatchRoomInitial(true)))
 	// send an update
 	v2.queueResponse(alice, sync2.SyncResponse{
@@ -425,7 +425,7 @@ func TestDuplicateEventsInTimeline(t *testing.T) {
 		}},
 	})
 	m.MatchResponse(t, res, m.MatchList("a",
-		m.MatchV3Ops(m.MatchV3SyncOp(0, 10, []string{roomID})),
+		m.MatchV3Ops(m.MatchV3SyncOp(0, 0, []string{roomID})),
 	), m.MatchRoomSubscription(roomID, m.MatchRoomTimelineMostRecent(1, []json.RawMessage{dupeEvent})))
 }
 
@@ -572,7 +572,7 @@ func TestHistoryDoesntIncludeState(t *testing.T) {
 		}},
 	})
 	m.MatchResponse(t, res, m.MatchList("a",
-		m.MatchV3Ops(m.MatchV3SyncOp(0, 10, []string{roomID})),
+		m.MatchV3Ops(m.MatchV3SyncOp(0, 0, []string{roomID})),
 	), m.MatchRoomSubscription(roomID, m.MatchRoomTimeline(room.events), m.MatchRoomPrevBatch(prevBatch)))
 }
 
@@ -762,7 +762,7 @@ func TestPrevBatchInTimeline(t *testing.T) {
 	})
 	m.MatchResponse(t, res, m.MatchList("a",
 		m.MatchV3Ops(
-			m.MatchV3SyncOp(0, 10, []string{roomID}),
+			m.MatchV3SyncOp(0, 0, []string{roomID}),
 		),
 	), m.MatchRoomSubscription(roomID, m.MatchRoomPrevBatch("")))
 
@@ -814,7 +814,7 @@ func TestPrevBatchInTimeline(t *testing.T) {
 		})
 		m.MatchResponse(t, res, m.MatchList("a",
 			m.MatchV3Ops(
-				m.MatchV3SyncOp(0, 10, []string{roomID}),
+				m.MatchV3SyncOp(0, 0, []string{roomID}),
 			),
 		), m.MatchRoomSubscription(roomID, m.MatchRoomPrevBatch(tc.wantPrevBatch)))
 	}


### PR DESCRIPTION
Closes #52.

The commit history may be enlightening, but there is a lot of churn.

Each of the three changes I made independently required tests to be fixed up, so I think we can get away without new test coverage. I inspected all four uses of ResponseOpRange.ResponseOpRange and have updated three; the remainder is

https://github.com/matrix-org/sliding-sync/blob/2970cf9f2721a827a3b50ac211ed2bd603105cef/sync3/handler/connstate.go#L200-L218

which never exhibits the kind of overflow we want to avoid.