### PR TITLE
bugfix: fix #56 by sending the correct NID with each live event

### DIFF
--- a/sync3/handler/connstate_test.go
+++ b/sync3/handler/connstate_test.go
@@ -155,9 +155,7 @@ func TestConnStateInitial(t *testing.T) {
 
 	// bump A to the top
 	newEvent := testutils.NewEvent(t, "unimportant", "me", struct{}{}, testutils.WithTimestamp(timestampNow.Add(1*time.Second)))
-	dispatcher.OnNewEvents(context.Background(), roomA.RoomID, []json.RawMessage{
-		newEvent,
-	}, 1)
+	dispatcher.OnNewEvent(context.Background(), roomA.RoomID, newEvent, 1)
 
 	// request again for the diff
 	res, err = cs.OnIncomingRequest(context.Background(), ConnID, &sync3.Request{
@@ -197,9 +195,7 @@ func TestConnStateInitial(t *testing.T) {
 
 	// another message should just update
 	newEvent = testutils.NewEvent(t, "unimportant", "me", struct{}{}, testutils.WithTimestamp(timestampNow.Add(2*time.Second)))
-	dispatcher.OnNewEvents(context.Background(), roomA.RoomID, []json.RawMessage{
-		newEvent,
-	}, 2)
+	dispatcher.OnNewEvent(context.Background(), roomA.RoomID, newEvent, 2)
 	res, err = cs.OnIncomingRequest(context.Background(), ConnID, &sync3.Request{
 		Lists: map[string]sync3.RequestList{"a": {
 			Sort: []string{sync3.SortByRecency},
@@ -330,9 +326,7 @@ func TestConnStateMultipleRanges(t *testing.T) {
 	// 8,0,1,2,3,4,5,6,7,9
 	//
 	newEvent := testutils.NewEvent(t, "unimportant", "me", struct{}{}, testutils.WithTimestamp(timestampNow.Time().Add(2*time.Second)))
-	dispatcher.OnNewEvents(context.Background(), roomIDs[8], []json.RawMessage{
-		newEvent,
-	}, 1)
+	dispatcher.OnNewEvent(context.Background(), roomIDs[8], newEvent, 1)
 
 	res, err = cs.OnIncomingRequest(context.Background(), ConnID, &sync3.Request{
 		Lists: map[string]sync3.RequestList{"a": {
@@ -372,9 +366,7 @@ func TestConnStateMultipleRanges(t *testing.T) {
 	// 8,0,1,9,2,3,4,5,6,7 room
 	middleTimestamp := int64((roomIDToRoom[roomIDs[1]].LastMessageTimestamp + roomIDToRoom[roomIDs[2]].LastMessageTimestamp) / 2)
 	newEvent = testutils.NewEvent(t, "unimportant", "me", struct{}{}, testutils.WithTimestamp(gomatrixserverlib.Timestamp(middleTimestamp).Time()))
-	dispatcher.OnNewEvents(context.Background(), roomIDs[9], []json.RawMessage{
-		newEvent,
-	}, 1)
+	dispatcher.OnNewEvent(context.Background(), roomIDs[9], newEvent, 1)
 	t.Logf("new event %s : %s", roomIDs[9], string(newEvent))
 	res, err = cs.OnIncomingRequest(context.Background(), ConnID, &sync3.Request{
 		Lists: map[string]sync3.RequestList{"a": {
@@ -477,9 +469,7 @@ func TestBumpToOutsideRange(t *testing.T) {
 
 	// D gets bumped to C's position but it's still outside the range so nothing should happen
 	newEvent := testutils.NewEvent(t, "unimportant", "me", struct{}{}, testutils.WithTimestamp(gomatrixserverlib.Timestamp(roomC.LastMessageTimestamp+2).Time()))
-	dispatcher.OnNewEvents(context.Background(), roomD.RoomID, []json.RawMessage{
-		newEvent,
-	}, 1)
+	dispatcher.OnNewEvent(context.Background(), roomD.RoomID, newEvent, 1)
 
 	// expire the context after 10ms so we don't wait forevar
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
@@ -612,9 +602,7 @@ func TestConnStateRoomSubscriptions(t *testing.T) {
 	})
 	// room D gets a new event but it's so old it doesn't bump to the top of the list
 	newEvent := testutils.NewEvent(t, "unimportant", "me", struct{}{}, testutils.WithTimestamp(gomatrixserverlib.Timestamp(timestampNow-20000).Time()))
-	dispatcher.OnNewEvents(context.Background(), roomD.RoomID, []json.RawMessage{
-		newEvent,
-	}, 1)
+	dispatcher.OnNewEvent(context.Background(), roomD.RoomID, newEvent, 1)
 	// we should get this message even though it's not in the range because we are subscribed to this room.
 	res, err = cs.OnIncomingRequest(context.Background(), ConnID, &sync3.Request{
 		Lists: map[string]sync3.RequestList{"a": {

--- a/sync3/handler/handler.go
+++ b/sync3/handler/handler.go
@@ -512,7 +512,9 @@ func (h *SyncLiveHandler) Accumulate(p *pubsub.V2Accumulate) {
 	}
 	internal.Logf(ctx, "room", fmt.Sprintf("%s: %d events", p.RoomID, len(events)))
 	// we have new events, notify active connections
-	h.Dispatcher.OnNewEvents(ctx, p.RoomID, events, p.EventNIDs[len(p.EventNIDs)-1])
+	for i := range events {
+		h.Dispatcher.OnNewEvent(ctx, p.RoomID, events[i], p.EventNIDs[i])
+	}
 }
 
 // Called from the v2 poller, implements V2DataReceiver

--- a/tests-e2e/num_live_test.go
+++ b/tests-e2e/num_live_test.go
@@ -122,7 +122,6 @@ func TestNumLive(t *testing.T) {
 	m.MatchResponse(t, res, m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
 		roomID: {
 			m.MatchNumLive(2),
-			// TODO: should we be including event ID 2 given timeline limit is 2?
 			MatchRoomTimeline([]Event{{ID: eventID2}, {ID: eventID3}, {ID: eventID4}}),
 		},
 	}))

--- a/tests-integration/timeline_test.go
+++ b/tests-integration/timeline_test.go
@@ -1055,7 +1055,7 @@ func TestNumLiveBulk(t *testing.T) {
 			},
 		},
 	), m.MatchList("the_list", m.MatchV3Count(1), m.MatchV3Ops(
-		m.MatchV3SyncOp(0, 1, []string{roomID}),
+		m.MatchV3SyncOp(0, 0, []string{roomID}),
 	)))
 
 	// inject 10 events in batches of 2, 1, 3, 4

--- a/tests-integration/timeline_test.go
+++ b/tests-integration/timeline_test.go
@@ -1011,3 +1011,84 @@ func TestTrickling(t *testing.T) {
 		)
 	}
 }
+
+func TestNumLiveBulk(t *testing.T) {
+	v2 := runTestV2Server(t)
+	v3 := runTestServer(t, v2, "")
+	defer v2.close()
+	defer v3.close()
+
+	roomID := "!bulk:test"
+	v2.addAccount(alice, aliceToken)
+	v2.queueResponse(alice, sync2.SyncResponse{
+		Rooms: sync2.SyncRoomsResponse{
+			Join: v2JoinTimeline(roomEvents{
+				roomID: roomID,
+				state:  createRoomState(t, alice, time.Now()),
+				events: []json.RawMessage{
+					testutils.NewEvent(t, "m.room.message", alice, map[string]interface{}{"body": "A"}, testutils.WithTimestamp(time.Now().Add(time.Second))),
+				},
+			}),
+		},
+	})
+
+	// initial syncs -> no live events
+	res := v3.mustDoV3Request(t, aliceToken, sync3.Request{
+		Lists: map[string]sync3.RequestList{
+			"the_list": {
+				RoomSubscription: sync3.RoomSubscription{
+					TimelineLimit: 3,
+					RequiredState: [][2]string{
+						{"m.room.encryption", ""},
+						{"m.room.tombstone", ""},
+					},
+				},
+				Sort:   []string{sync3.SortByRecency, sync3.SortByName},
+				Ranges: sync3.SliceRanges{{0, 1}},
+			},
+		},
+	})
+	m.MatchResponse(t, res, m.MatchRoomSubscriptionsStrict(
+		map[string][]m.RoomMatcher{
+			roomID: {
+				m.MatchNumLive(0),
+			},
+		},
+	), m.MatchList("the_list", m.MatchV3Count(1), m.MatchV3Ops(
+		m.MatchV3SyncOp(0, 1, []string{roomID}),
+	)))
+
+	// inject 10 events in batches of 2, 1, 3, 4
+	batchSizes := []int{2, 1, 3, 4}
+	count := 0
+	var completeTimeline []json.RawMessage
+	for _, sz := range batchSizes {
+		var timeline []json.RawMessage
+		for i := 0; i < sz; i++ {
+			timeline = append(timeline, testutils.NewEvent(
+				t, "m.room.message",
+				alice, map[string]interface{}{"body": fmt.Sprintf("Msg %d", count)}, testutils.WithTimestamp(time.Now().Add(time.Minute*time.Duration(1+count))),
+			))
+			count++
+		}
+		v2.queueResponse(aliceToken, sync2.SyncResponse{
+			Rooms: sync2.SyncRoomsResponse{
+				Join: v2JoinTimeline(roomEvents{
+					roomID: roomID,
+					events: timeline,
+				}),
+			},
+		})
+		v2.waitUntilEmpty(t, aliceToken)
+		completeTimeline = append(completeTimeline, timeline...)
+	}
+	res = v3.mustDoV3RequestWithPos(t, aliceToken, res.Pos, sync3.Request{})
+	m.MatchResponse(t, res, m.MatchRoomSubscriptionsStrict(
+		map[string][]m.RoomMatcher{
+			roomID: {
+				m.MatchRoomTimeline(completeTimeline),
+				m.MatchNumLive(10),
+			},
+		},
+	))
+}


### PR DESCRIPTION
Early versions of the proxy tended to send a list of event JSONs and the "latest" NID for that batch. This then interacted badly with later code which used these NIDs to determine if the event in question should be returned to the client or not. We sometimes filter them out in cases where the "initial" room has already included this event, e.g room has msgs A,B,C which were pulled in initially via a DB call, then we receive C down as an update, we should not include it else we will send back A,B,C,C. By only sending the "latest" NID, we will filter out other events in that batch as they are <= the previously seen latest NID.

This was not tested in E2E tests because it relies on slow pollers which cause >1 timeline event for a single room to arrive. This may be a cause of flakey tests. We now have an integration test for this which injected batches of events for the same room and ensures they are all seen down the connection.

Thanks to @jplatte and @manuroe for helping debug this.
