### PR TITLE
Remove unreachable err handling in setupConnection

### DIFF
--- a/sync3/handler/handler.go
+++ b/sync3/handler/handler.go
@@ -285,13 +285,6 @@ func (h *SyncLiveHandler) setupConnection(req *http.Request, syncReq *sync3.Requ
 		conn = h.ConnMap.Conn(sync3.ConnID{
 			DeviceID: deviceID,
 		})
-		if err != nil {
-			log.Warn().Err(err).Msg("failed to lookup conn for request")
-			return nil, &internal.HandlerError{
-				StatusCode: 400,
-				Err:        err,
-			}
-		}
 		if conn != nil {
 			log.Trace().Str("conn", conn.ConnID.String()).Msg("reusing conn")
 			return conn, nil


### PR DESCRIPTION
If `err` is nonnil in the removed snippet, then it was also nonnil after the call to `internal.HashedTokenFromRequest` above, meaning that we would have returned before reaching the removed snippet.

(This shouldn't change anything at runtime, but by pruning it out I'm finding it easier to reason about what this does for #51.)