### PR TITLE
Fix #59: flakey conn_test

### DIFF
--- a/sync3/conn_test.go
+++ b/sync3/conn_test.go
@@ -86,7 +86,7 @@ func TestConnBlocking(t *testing.T) {
 	ch := make(chan string)
 	c := NewConn(connID, &connHandlerMock{func(ctx context.Context, cid ConnID, req *Request, init bool) (*Response, error) {
 		if req.Lists["a"].Sort[0] == "hi" {
-			sentFirstWg.Done()                // tell the 2nd request is can start
+			sentFirstWg.Done()                // tell the 2nd request it can start
 			time.Sleep(20 * time.Millisecond) // simulate a long processing time
 		}
 		ch <- req.Lists["a"].Sort[0]

--- a/sync3/conn_test.go
+++ b/sync3/conn_test.go
@@ -80,10 +80,14 @@ func TestConnBlocking(t *testing.T) {
 	connID := ConnID{
 		DeviceID: "d",
 	}
+	// synchronisation point which is done when the first request begins to block
+	var sentFirstWg sync.WaitGroup
+	sentFirstWg.Add(1)
 	ch := make(chan string)
 	c := NewConn(connID, &connHandlerMock{func(ctx context.Context, cid ConnID, req *Request, init bool) (*Response, error) {
 		if req.Lists["a"].Sort[0] == "hi" {
-			time.Sleep(10 * time.Millisecond)
+			sentFirstWg.Done()                // tell the 2nd request is can start
+			time.Sleep(20 * time.Millisecond) // simulate a long processing time
 		}
 		ch <- req.Lists["a"].Sort[0]
 		return &Response{}, nil
@@ -106,7 +110,8 @@ func TestConnBlocking(t *testing.T) {
 	}()
 	go func() {
 		defer wg.Done()
-		time.Sleep(1 * time.Millisecond) // this req happens 2nd
+		// wait until the first request has begun to block
+		sentFirstWg.Wait()
 		c.OnIncomingRequest(ctx, &Request{
 			Lists: map[string]RequestList{
 				"a": {


### PR DESCRIPTION
The fundamental issue here is that it isn't possible to express the following in Go:
 - Call this function, and then do this other thing _before the function returns_

We need to use callbacks for that. Unfortunately, this wasn't done correctly in this test, and we just took a shortcut:
 - start a new goroutine and call function
 - start a 2nd goroutine, sleep a bit, call function

We assumed that the first goroutine had called the function by the time the sleep had finished. This assumption isn't always true on slow machines, hence the flake.

The fix is to wait for the first request to get to the conn handler, and THEN send the 2nd request.
