### PR TITLE
Additional sentry logging

### DIFF
--- a/state/storage.go
+++ b/state/storage.go
@@ -46,8 +46,9 @@ type Storage struct {
 func NewStorage(postgresURI string) *Storage {
 	db, err := sqlx.Open("postgres", postgresURI)
 	if err != nil {
-		logger.Panic().Err(err).Str("uri", postgresURI).Msg("failed to open SQL DB")
 		sentry.CaptureException(err)
+		// TODO: if we panic(), will sentry have a chance to flush the event?
+		logger.Panic().Err(err).Str("uri", postgresURI).Msg("failed to open SQL DB")
 	}
 	acc := &Accumulator{
 		db:            db,

--- a/sync2/storage.go
+++ b/sync2/storage.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"github.com/getsentry/sentry-go"
 	"io"
 	"os"
 	"strings"
@@ -44,6 +45,8 @@ type Storage struct {
 func NewStore(postgresURI, secret string) *Storage {
 	db, err := sqlx.Open("postgres", postgresURI)
 	if err != nil {
+		sentry.CaptureException(err)
+		// TODO: if we panic(), will sentry have a chance to flush the event?
 		log.Panic().Err(err).Str("uri", postgresURI).Msg("failed to open SQL DB")
 	}
 	db.MustExec(`

--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -249,7 +249,7 @@ func (s *ConnState) onIncomingListRequest(ctx context.Context, builder *RoomsBui
 				}
 				responseOperations = append(responseOperations, &sync3.ResponseOpRange{
 					Operation: sync3.OpInvalidate,
-					Range:     clampSliceRangeToListSize(r, int64(len(allRoomIDs))),
+					Range:     clampSliceRangeToListSize(ctx, r, int64(len(allRoomIDs))),
 				})
 			}
 		}
@@ -278,7 +278,7 @@ func (s *ConnState) onIncomingListRequest(ctx context.Context, builder *RoomsBui
 		}
 		responseOperations = append(responseOperations, &sync3.ResponseOpRange{
 			Operation: sync3.OpInvalidate,
-			Range:     clampSliceRangeToListSize(removedRanges[i], roomList.Len()),
+			Range:     clampSliceRangeToListSize(ctx, removedRanges[i], roomList.Len()),
 		})
 	}
 
@@ -299,7 +299,7 @@ func (s *ConnState) onIncomingListRequest(ctx context.Context, builder *RoomsBui
 
 		responseOperations = append(responseOperations, &sync3.ResponseOpRange{
 			Operation: sync3.OpSync,
-			Range:     clampSliceRangeToListSize(addedRanges[i], roomList.Len()),
+			Range:     clampSliceRangeToListSize(ctx, addedRanges[i], roomList.Len()),
 			RoomIDs:   roomIDs,
 		})
 	}
@@ -566,9 +566,9 @@ func (s *ConnState) OnRoomUpdate(ctx context.Context, up caches.RoomUpdate) {
 // The "full" room list occupies positions [0, totalRooms - 1]. If the given range r
 // does not overlap the full room list, return nil. Otherwise, return the intersection
 // of r with the full room list.
-func clampSliceRangeToListSize(r [2]int64, totalRooms int64) [2]int64 {
+func clampSliceRangeToListSize(ctx context.Context, r [2]int64, totalRooms int64) [2]int64 {
 	lastIndexWithRoom := totalRooms - 1
-	internal.Assert("Start of range exceeds last room index in list", r[0] <= lastIndexWithRoom)
+	internal.AssertWithContext(ctx, "Start of range exceeds last room index in list", r[0] <= lastIndexWithRoom)
 	if r[1] <= lastIndexWithRoom {
 		return r
 	} else {

--- a/sync3/handler/handler.go
+++ b/sync3/handler/handler.go
@@ -187,6 +187,7 @@ func (h *SyncLiveHandler) serve(w http.ResponseWriter, req *http.Request) error 
 		defer req.Body.Close()
 		if err := json.NewDecoder(req.Body).Decode(&requestBody); err != nil {
 			log.Err(err).Msg("failed to read/decode request body")
+			internal.GetSentryHubFromContextOrDefault(req.Context()).CaptureException(err)
 			return &internal.HandlerError{
 				StatusCode: 400,
 				Err:        err,
@@ -205,6 +206,7 @@ func (h *SyncLiveHandler) serve(w http.ResponseWriter, req *http.Request) error 
 	conn, err := h.setupConnection(req, &requestBody, req.URL.Query().Get("pos") != "")
 	if err != nil {
 		hlog.FromRequest(req).Err(err).Msg("failed to get or create Conn")
+		internal.GetSentryHubFromContextOrDefault(req.Context()).CaptureException(err)
 		return err
 	}
 	// set pos and timeout if specified
@@ -233,6 +235,7 @@ func (h *SyncLiveHandler) serve(w http.ResponseWriter, req *http.Request) error 
 	resp, herr := conn.OnIncomingRequest(req.Context(), &requestBody)
 	if herr != nil {
 		log.Err(herr).Msg("failed to OnIncomingRequest")
+		internal.GetSentryHubFromContextOrDefault(req.Context()).CaptureException(herr)
 		return herr
 	}
 	// for logging

--- a/v3.go
+++ b/v3.go
@@ -169,8 +169,9 @@ func RunSyncV3Server(h http.Handler, bindAddr, destV2Server, tlsCert, tlsKey str
 		err = http.ListenAndServe(bindAddr, srv)
 	}
 	if err != nil {
-		logger.Fatal().Err(err).Msg("failed to listen and serve")
 		sentry.CaptureException(err)
+		// TODO: Fatal() calls os.Exit. Will that give time for sentry.Flush() to run?
+		logger.Fatal().Err(err).Msg("failed to listen and serve")
 	}
 }
 


### PR DESCRIPTION
I'd missed that there were a bunch of logger calls that weren't using a logger called `logger`. Also a few other sentry fixups.

Part of #41.