### PR TITLE
Include the date in logging timestamps

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -7,13 +7,14 @@ import (
 	"github.com/getsentry/sentry-go"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/rs/zerolog"
 )
 
 var logger = zerolog.New(os.Stdout).With().Timestamp().Logger().Output(zerolog.ConsoleWriter{
 	Out:        os.Stderr,
-	TimeFormat: "15:04:05",
+	TimeFormat: time.RFC3339,
 })
 
 type HandlerError struct {


### PR DESCRIPTION
### Pull Request Checklist

solves issue #68 

date format now: `2022-09-02T08:20:47+01:00`

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

