### PR TITLE
Inject state blocks from incremental polls into the room timeline

### DIFF
--- a/state/accumulator.go
+++ b/state/accumulator.go
@@ -229,7 +229,7 @@ func (a *Accumulator) Initialise(roomID string, state []json.RawMessage) (res In
 					"snapshot_id":       snapshotID,
 					"num_insert_events": len(insertEvents),
 				})
-				sentry.CaptureException(fmt.Errorf("Accumulator.Initialise: patching in events", len(insertEvents)))
+				sentry.CaptureException(fmt.Errorf("Accumulator.Initialise: patching in %d events", len(insertEvents)))
 			})
 		}
 

--- a/state/accumulator.go
+++ b/state/accumulator.go
@@ -187,7 +187,7 @@ func (a *Accumulator) Initialise(roomID string, state []json.RawMessage) (Initia
 				eventIDToRawEvent[eventID.Str] = state[i]
 				eventIDs[i] = eventID.Str
 			}
-			unknownEventIDs, err := a.eventsTable.SelectUnknownEventIDs(txn, roomID, eventIDs)
+			unknownEventIDs, err := a.eventsTable.SelectUnknownEventIDs(txn, eventIDs)
 			if err != nil {
 				return fmt.Errorf("error determing which event IDs are unknown: %s", err)
 			}

--- a/state/accumulator.go
+++ b/state/accumulator.go
@@ -208,6 +208,8 @@ func (a *Accumulator) Initialise(roomID string, state []json.RawMessage) (res In
 			}
 		Outer:
 			for i := range events {
+				// TODO: should this be a set of ids? Otherwise the double loop is
+				// quadratic in the size of the gap.
 				for j := range unknownEventIDs {
 					if events[i].ID == unknownEventIDs[j] {
 						insertEvents = append(insertEvents, events[i])

--- a/state/accumulator.go
+++ b/state/accumulator.go
@@ -187,7 +187,7 @@ func (a *Accumulator) Initialise(roomID string, state []json.RawMessage) (Initia
 				eventIDToRawEvent[eventID.Str] = state[i]
 				eventIDs[i] = eventID.Str
 			}
-			unknownEventIDs, err := a.eventsTable.SelectUnknownEventIDs(txn, eventIDs)
+			unknownEventIDs, err := a.eventsTable.SelectUnknownEventIDs(txn, roomID, eventIDs)
 			if err != nil {
 				return fmt.Errorf("error determing which event IDs are unknown: %s", err)
 			}

--- a/state/accumulator.go
+++ b/state/accumulator.go
@@ -163,6 +163,15 @@ func (a *Accumulator) Initialise(roomID string, state []json.RawMessage) (res In
 		}
 		unknownRoom := snapshotID == 0
 		if !unknownRoom {
+			// TODO: suppose Alice's poller has already initialised this room. Then Bob
+			// shows up and we make a brand new poller for him. When his poller initial
+			// syncs, the state block will be passed here. If that block includes a
+			// state event that Alice's poller hasn't seen, we'll now end up adding it
+			// to the DB here---without a snapshot ID---instead of in an Accumulate
+			// call (with a snapshot ID).
+			//
+			// Can we prevent this by passing in a bool initialPollerSync arg?
+			// (Return early if !initialPollerSync and !unknownRoom)
 			const warningMsg = "Accumulator.Initialise called when current snapshot already exists. Patching in events"
 			logger.Warn().Str("room_id", roomID).Int64("snapshot_id", snapshotID).Msg(warningMsg)
 			sentry.WithScope(func(scope *sentry.Scope) {

--- a/state/accumulator.go
+++ b/state/accumulator.go
@@ -181,7 +181,7 @@ func (a *Accumulator) Initialise(roomID string, state []json.RawMessage) (Initia
 			for i := range state {
 				eventIDs[i] = gjson.ParseBytes(state[i]).Get("event_id").Str
 			}
-			unknownEventIDs, err := a.eventsTable.SelectUnknownEventIDs(txn, eventIDs)
+			unknownEventIDs, err := a.eventsTable.SelectUnknownEventIds(txn, roomID, eventIDs)
 			if err != nil {
 				return fmt.Errorf("error determing which event IDs are unknown: %s", err)
 			}

--- a/state/accumulator.go
+++ b/state/accumulator.go
@@ -208,7 +208,7 @@ func (a *Accumulator) Initialise(roomID string, state []json.RawMessage) (res In
 			}
 			unknownEventIDs, err := a.eventsTable.SelectUnknownEventIDs(txn, eventIDs)
 			if err != nil {
-				return fmt.Errorf("error determing which event IDs are unknown")
+				return fmt.Errorf("error determing which event IDs are unknown: %s", err)
 			}
 			if len(unknownEventIDs) == 0 {
 				// All events known. Odd, but nothing to do.

--- a/state/accumulator_test.go
+++ b/state/accumulator_test.go
@@ -23,11 +23,11 @@ func TestAccumulatorInitialise(t *testing.T) {
 	db, close := connectToDB(t)
 	defer close()
 	accumulator := NewAccumulator(db)
-	added, initSnapID, err := accumulator.Initialise(roomID, roomEvents)
+	res, err := accumulator.Initialise(roomID, roomEvents)
 	if err != nil {
 		t.Fatalf("falied to Initialise accumulator: %s", err)
 	}
-	if !added {
+	if !res.AddedEvents {
 		t.Fatalf("didn't add events, wanted it to")
 	}
 
@@ -45,8 +45,8 @@ func TestAccumulatorInitialise(t *testing.T) {
 	if snapID == 0 {
 		t.Fatalf("Initialise did not store a current snapshot")
 	}
-	if snapID != initSnapID {
-		t.Fatalf("Initialise returned wrong snapshot ID, got %v want %v", initSnapID, snapID)
+	if snapID != res.SnapshotID {
+		t.Fatalf("Initialise returned wrong snapshot ID, got %v want %v", res.SnapshotID, snapID)
 	}
 
 	// this snapshot should have 1 member event and 2 other events in it
@@ -80,11 +80,11 @@ func TestAccumulatorInitialise(t *testing.T) {
 	}
 
 	// Subsequent calls do nothing and are not an error
-	added, _, err = accumulator.Initialise(roomID, roomEvents)
+	res, err = accumulator.Initialise(roomID, roomEvents)
 	if err != nil {
 		t.Fatalf("falied to Initialise accumulator: %s", err)
 	}
-	if added {
+	if res.AddedEvents {
 		t.Fatalf("added events when it shouldn't have")
 	}
 }
@@ -99,7 +99,7 @@ func TestAccumulatorAccumulate(t *testing.T) {
 	db, close := connectToDB(t)
 	defer close()
 	accumulator := NewAccumulator(db)
-	_, _, err := accumulator.Initialise(roomID, roomEvents)
+	_, err := accumulator.Initialise(roomID, roomEvents)
 	if err != nil {
 		t.Fatalf("failed to Initialise accumulator: %s", err)
 	}
@@ -195,7 +195,7 @@ func TestAccumulatorDelta(t *testing.T) {
 	db, close := connectToDB(t)
 	defer close()
 	accumulator := NewAccumulator(db)
-	_, _, err := accumulator.Initialise(roomID, nil)
+	_, err := accumulator.Initialise(roomID, nil)
 	if err != nil {
 		t.Fatalf("failed to Initialise accumulator: %s", err)
 	}
@@ -244,7 +244,7 @@ func TestAccumulatorMembershipLogs(t *testing.T) {
 	db, close := connectToDB(t)
 	defer close()
 	accumulator := NewAccumulator(db)
-	_, _, err := accumulator.Initialise(roomID, nil)
+	_, err := accumulator.Initialise(roomID, nil)
 	if err != nil {
 		t.Fatalf("failed to Initialise accumulator: %s", err)
 	}
@@ -384,7 +384,7 @@ func TestAccumulatorDupeEvents(t *testing.T) {
 	defer close()
 	accumulator := NewAccumulator(db)
 	roomID := "!buggy:localhost"
-	_, _, err := accumulator.Initialise(roomID, joinRoom.State.Events)
+	_, err := accumulator.Initialise(roomID, joinRoom.State.Events)
 	if err != nil {
 		t.Fatalf("failed to Initialise accumulator: %s", err)
 	}
@@ -426,7 +426,7 @@ func TestAccumulatorMisorderedGraceful(t *testing.T) {
 	accumulator := NewAccumulator(db)
 	roomID := "!TestAccumulatorStateReset:localhost"
 	// Create a room with initial state A,C
-	_, _, err := accumulator.Initialise(roomID, []json.RawMessage{
+	_, err := accumulator.Initialise(roomID, []json.RawMessage{
 		eventA, eventC,
 	})
 	if err != nil {

--- a/state/event_table.go
+++ b/state/event_table.go
@@ -149,6 +149,8 @@ func (t *EventTable) SelectHighestNID() (highest int64, err error) {
 }
 
 // Insert events into the event table. Returns a map of event ID to NID for new events only.
+// The NIDs assigned to new events will respect the order of the given events, e.g. if
+// we insert new events A and B in that order, then NID(A) < NID(B).
 func (t *EventTable) Insert(txn *sqlx.Tx, events []Event, checkFields bool) (map[string]int, error) {
 	if checkFields {
 		ensureFieldsSet(events)
@@ -211,6 +213,10 @@ func (t *EventTable) SelectByNIDs(txn *sqlx.Tx, verifyAll bool, nids []int64) (e
 	WHERE event_nid = ANY ($1) ORDER BY event_nid ASC;`, pq.Int64Array(nids))
 }
 
+// SelectByIDs fetches all events with the given event IDs from the DB as Event structs.
+// If verifyAll is true, the function will check that each event ID has a matching
+// event row in the database. The returned events are ordered by ascending NID; the
+// order of the event IDs is irrelevant.
 func (t *EventTable) SelectByIDs(txn *sqlx.Tx, verifyAll bool, ids []string) (events []Event, err error) {
 	wanted := 0
 	if verifyAll {

--- a/state/event_table.go
+++ b/state/event_table.go
@@ -267,18 +267,18 @@ func (t *EventTable) SelectStrippedEventsByIDs(txn *sqlx.Tx, verifyAll bool, ids
 
 // SelectUnknownEventIDs accepts a list of event IDs and returns the subset of those which are not known to the DB.
 // It MUST be called within a transaction, or else will panic.
-func (t *EventTable) SelectUnknownEventIDs(txn *sqlx.Tx, maybeUnknownEventIDs []string) (map[string]struct{}, error) {
+func (t *EventTable) SelectUnknownEventIDs(txn *sqlx.Tx, roomID string, maybeUnknownEventIDs []string) (map[string]struct{}, error) {
 	// Note: in practice, the order of rows returned matches the order of rows of
 	// array entries. But I don't think that's guaranteed. Return an (unordered) set
 	// out of paranoia.
 	queryStr := `
-	WITH maybe_unknown_events(event_id) AS (SELECT unnest($1::text[]))
+	WITH maybe_unknown_events(event_id) AS (SELECT unnest($2::text[]))
 	SELECT event_id
 	FROM maybe_unknown_events LEFT JOIN syncv3_events USING(event_id)
-	WHERE event_nid IS NULL;`
+	WHERE room_id = $1 AND event_nid IS NULL;`
 
 	var unknownEventIDs []string
-	if err := txn.Select(&unknownEventIDs, queryStr, pq.StringArray(maybeUnknownEventIDs)); err != nil {
+	if err := txn.Select(&unknownEventIDs, queryStr, roomID, pq.StringArray(maybeUnknownEventIDs)); err != nil {
 		return nil, err
 	}
 	unknownMap := make(map[string]struct{}, len(unknownEventIDs))

--- a/state/event_table.go
+++ b/state/event_table.go
@@ -271,9 +271,9 @@ func (t *EventTable) SelectUnknownEventIDs(txn *sqlx.Tx, maybeUnknownEventIDs []
 	var unknownEventIDs []string
 	var err error
 	if txn != nil {
-		err = txn.Select(&unknownEventIDs, queryStr, maybeUnknownEventIDs)
+		err = txn.Select(&unknownEventIDs, queryStr, pq.StringArray(maybeUnknownEventIDs))
 	} else {
-		err = t.db.Select(&unknownEventIDs, queryStr, maybeUnknownEventIDs)
+		err = t.db.Select(&unknownEventIDs, queryStr, pq.StringArray(maybeUnknownEventIDs))
 	}
 	return unknownEventIDs, err
 }

--- a/state/event_table.go
+++ b/state/event_table.go
@@ -267,18 +267,18 @@ func (t *EventTable) SelectStrippedEventsByIDs(txn *sqlx.Tx, verifyAll bool, ids
 
 // SelectUnknownEventIDs accepts a list of event IDs and returns the subset of those which are not known to the DB.
 // It MUST be called within a transaction, or else will panic.
-func (t *EventTable) SelectUnknownEventIDs(txn *sqlx.Tx, roomID string, maybeUnknownEventIDs []string) (map[string]struct{}, error) {
+func (t *EventTable) SelectUnknownEventIDs(txn *sqlx.Tx, maybeUnknownEventIDs []string) (map[string]struct{}, error) {
 	// Note: in practice, the order of rows returned matches the order of rows of
 	// array entries. But I don't think that's guaranteed. Return an (unordered) set
 	// out of paranoia.
 	queryStr := `
-	WITH maybe_unknown_events(event_id) AS (SELECT unnest($2::text[]))
+	WITH maybe_unknown_events(event_id) AS (SELECT unnest($1::text[]))
 	SELECT event_id
 	FROM maybe_unknown_events LEFT JOIN syncv3_events USING(event_id)
-	WHERE room_id = $1 AND event_nid IS NULL;`
+	WHERE event_nid IS NULL;`
 
 	var unknownEventIDs []string
-	if err := txn.Select(&unknownEventIDs, queryStr, roomID, pq.StringArray(maybeUnknownEventIDs)); err != nil {
+	if err := txn.Select(&unknownEventIDs, queryStr, pq.StringArray(maybeUnknownEventIDs)); err != nil {
 		return nil, err
 	}
 	unknownMap := make(map[string]struct{}, len(unknownEventIDs))

--- a/state/event_table_test.go
+++ b/state/event_table_test.go
@@ -918,7 +918,7 @@ func TestSelectUnknownEventIDs(t *testing.T) {
 	// Someone else tells us the state of the room is {A, C}. Query which of those
 	// event IDs are unknown.
 	stateBlockIDs := []string{"$A", "$C"}
-	unknownIDs, err := table.SelectUnknownEventIDs(txn, roomID, stateBlockIDs)
+	unknownIDs, err := table.SelectUnknownEventIDs(txn, stateBlockIDs)
 	t.Logf("unknownIDs=%v", unknownIDs)
 	if err != nil {
 		t.Errorf("failed to select unknown state events: %s", err)

--- a/state/event_table_test.go
+++ b/state/event_table_test.go
@@ -879,10 +879,10 @@ func TestEventTableSelectUnknownEventIDs(t *testing.T) {
 		t.Fatalf("failed to start txn: %s", err)
 	}
 	defer txn.Rollback()
-	const roomID = "!1:localhost"
+	const roomID = "!1TestEventTableSelectUnknownEventIDs:localhost"
 
 	// Note: there shouldn't be any other events with these IDs inserted before this
-	// transaction. $A and $B seem to be inserted and commit in TestEventTablePrevBatch.
+	// transaction. "$A" and "$B" seem to be inserted and commit in TestEventTablePrevBatch.
 	const eventID1 = "$A-SelectUnknownEventIDs"
 	const eventID2 = "$B-SelectUnknownEventIDs"
 
@@ -930,7 +930,7 @@ func TestEventTableSelectUnknownEventIDs(t *testing.T) {
 	// event IDs are unknown.
 	shouldBeUnknownIDs := []string{"$C-SelectUnknownEventIDs", "$D-SelectUnknownEventIDs"}
 	stateBlockIDs := append(shouldBeUnknownIDs, eventID1)
-	unknownIDs, err := table.SelectUnknownEventIDs(txn, stateBlockIDs)
+	unknownIDs, err := table.SelectUnknownEventIDs(txn, roomID, stateBlockIDs)
 	t.Logf("unknownIDs=%v", unknownIDs)
 	if err != nil {
 		t.Fatalf("failed to select unknown state events: %s", err)

--- a/state/event_table_test.go
+++ b/state/event_table_test.go
@@ -871,7 +871,7 @@ func TestRemoveUnsignedTXNID(t *testing.T) {
 	}
 }
 
-func TestSelectUnknownEventIds(t *testing.T) {
+func TestSelectUnknownEventIDs(t *testing.T) {
 	db, close := connectToDB(t)
 	defer close()
 	txn, err := db.Beginx()
@@ -918,7 +918,7 @@ func TestSelectUnknownEventIds(t *testing.T) {
 	// Someone else tells us the state of the room is {A, C}. Query which of those
 	// event IDs are unknown.
 	stateBlockIDs := []string{"$A", "$C"}
-	unknownIDs, err := table.SelectUnknownEventIds(txn, roomID, stateBlockIDs)
+	unknownIDs, err := table.SelectUnknownEventIDs(txn, roomID, stateBlockIDs)
 	t.Logf("unknownIDs=%v", unknownIDs)
 	if err != nil {
 		t.Errorf("failed to select unknown state events: %s", err)

--- a/state/event_table_test.go
+++ b/state/event_table_test.go
@@ -928,20 +928,21 @@ func TestEventTableSelectUnknownEventIDs(t *testing.T) {
 
 	// Someone else tells us the state of the room is {A, C}. Query which of those
 	// event IDs are unknown.
-	const unknownEventID = "$C-SelectUnknownEventIDs"
-	stateBlockIDs := []string{eventID1, unknownEventID}
+	shouldBeUnknownIDs := []string{"$C-SelectUnknownEventIDs", "$D-SelectUnknownEventIDs"}
+	stateBlockIDs := append(shouldBeUnknownIDs, eventID1)
 	unknownIDs, err := table.SelectUnknownEventIDs(txn, stateBlockIDs)
 	t.Logf("unknownIDs=%v", unknownIDs)
 	if err != nil {
 		t.Fatalf("failed to select unknown state events: %s", err)
 	}
 
-	// Only event C should be flagged as unknown.
-	if len(unknownIDs) != 1 {
-		t.Fatalf("Expected 1 unknown id, got %v", unknownIDs)
+	// Event C and D should be flagged as unknown.
+	if len(unknownIDs) != len(shouldBeUnknownIDs) {
+		t.Fatalf("Expected %d unknown ids, got %v", len(shouldBeUnknownIDs), unknownIDs)
 	}
-	_, ok := unknownIDs[unknownEventID]
-	if !ok {
-		t.Fatalf("Expected $C-SelectUnknownEventIDs to be unknown to the DB, but it wasn't")
+	for _, unknownEventID := range shouldBeUnknownIDs {
+		if _, ok := unknownIDs[unknownEventID]; !ok {
+			t.Errorf("Expected %s to be unknown to the DB, but it wasn't", unknownEventID)
+		}
 	}
 }

--- a/state/event_table_test.go
+++ b/state/event_table_test.go
@@ -879,10 +879,10 @@ func TestEventTableSelectUnknownEventIDs(t *testing.T) {
 		t.Fatalf("failed to start txn: %s", err)
 	}
 	defer txn.Rollback()
-	const roomID = "!1TestEventTableSelectUnknownEventIDs:localhost"
+	const roomID = "!1:localhost"
 
 	// Note: there shouldn't be any other events with these IDs inserted before this
-	// transaction. "$A" and "$B" seem to be inserted and commit in TestEventTablePrevBatch.
+	// transaction. $A and $B seem to be inserted and commit in TestEventTablePrevBatch.
 	const eventID1 = "$A-SelectUnknownEventIDs"
 	const eventID2 = "$B-SelectUnknownEventIDs"
 
@@ -930,7 +930,7 @@ func TestEventTableSelectUnknownEventIDs(t *testing.T) {
 	// event IDs are unknown.
 	shouldBeUnknownIDs := []string{"$C-SelectUnknownEventIDs", "$D-SelectUnknownEventIDs"}
 	stateBlockIDs := append(shouldBeUnknownIDs, eventID1)
-	unknownIDs, err := table.SelectUnknownEventIDs(txn, roomID, stateBlockIDs)
+	unknownIDs, err := table.SelectUnknownEventIDs(txn, stateBlockIDs)
 	t.Logf("unknownIDs=%v", unknownIDs)
 	if err != nil {
 		t.Fatalf("failed to select unknown state events: %s", err)

--- a/state/event_table_test.go
+++ b/state/event_table_test.go
@@ -920,7 +920,7 @@ func TestEventTableSelectUnknownEventIDs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to select events: %s", err)
 	}
-	if (gotEvents[0].ID == eventID1 && gotEvents[1].ID == eventID2) || (gotEvents[0].ID == eventID2 && gotEvents[1].ID == eventID1) {
+	if gotEvents[0].ID == eventID1 && gotEvents[1].ID == eventID2 {
 		t.Logf("Got expected event IDs after insert. NIDS: %s=%d, %s=%d", gotEvents[0].ID, gotEvents[0].NID, gotEvents[1].ID, gotEvents[1].NID)
 	} else {
 		t.Fatalf("Event ID mismatch: expected $A-SelectUnknownEventIDs and $B-SelectUnknownEventIDs, got %v", gotEvents)

--- a/state/storage.go
+++ b/state/storage.go
@@ -309,7 +309,7 @@ func (s *Storage) Accumulate(roomID, prevBatch string, timeline []json.RawMessag
 	return s.accumulator.Accumulate(roomID, prevBatch, timeline)
 }
 
-func (s *Storage) Initialise(roomID string, state []json.RawMessage) (bool, int64, error) {
+func (s *Storage) Initialise(roomID string, state []json.RawMessage) (InitialiseResult, error) {
 	return s.accumulator.Initialise(roomID, state)
 }
 

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -282,7 +282,7 @@ func TestVisibleEventNIDsBetween(t *testing.T) {
 		},
 	}
 	for roomID, eventMap := range roomIDToEventMap {
-		_, _, err := store.Initialise(roomID, eventMap)
+		_, err := store.Initialise(roomID, eventMap)
 		if err != nil {
 			t.Fatalf("Initialise on %s failed: %s", roomID, err)
 		}
@@ -512,7 +512,7 @@ func TestStorageLatestEventsInRoomsPrevBatch(t *testing.T) {
 		},
 	}
 
-	_, _, err := store.Initialise(roomID, stateEvents)
+	_, err := store.Initialise(roomID, stateEvents)
 	if err != nil {
 		t.Fatalf("failed to initialise: %s", err)
 	}
@@ -616,7 +616,7 @@ func TestGlobalSnapshot(t *testing.T) {
 	store := NewStorage(postgresConnectionString)
 	defer store.Teardown()
 	for roomID, stateEvents := range roomIDToEventMap {
-		_, _, err := store.Initialise(roomID, stateEvents)
+		_, err := store.Initialise(roomID, stateEvents)
 		assertNoError(t, err)
 	}
 	snapshot, err := store.GlobalSnapshot()

--- a/sync2/handler2/handler.go
+++ b/sync2/handler2/handler.go
@@ -241,19 +241,19 @@ func (h *Handler) Accumulate(deviceID, roomID, prevBatch string, timeline []json
 }
 
 func (h *Handler) Initialise(roomID string, state []json.RawMessage) {
-	added, snapID, err := h.Store.Initialise(roomID, state)
+	res, err := h.Store.Initialise(roomID, state)
 	if err != nil {
 		logger.Err(err).Int("state", len(state)).Str("room", roomID).Msg("V2: failed to initialise room")
 		sentry.CaptureException(err)
 		return
 	}
-	if !added {
+	if !res.AddedEvents {
 		// no new events
 		return
 	}
 	h.v2Pub.Notify(pubsub.ChanV2, &pubsub.V2Initialise{
 		RoomID:      roomID,
-		SnapshotNID: snapID,
+		SnapshotNID: res.SnapshotID,
 	})
 }
 

--- a/sync2/handler2/handler.go
+++ b/sync2/handler2/handler.go
@@ -240,21 +240,20 @@ func (h *Handler) Accumulate(deviceID, roomID, prevBatch string, timeline []json
 	})
 }
 
-func (h *Handler) Initialise(roomID string, state []json.RawMessage) {
+func (h *Handler) Initialise(roomID string, state []json.RawMessage) []json.RawMessage {
 	res, err := h.Store.Initialise(roomID, state)
 	if err != nil {
 		logger.Err(err).Int("state", len(state)).Str("room", roomID).Msg("V2: failed to initialise room")
 		sentry.CaptureException(err)
-		return
+		return nil
 	}
-	if !res.AddedEvents {
-		// no new events
-		return
+	if res.AddedEvents {
+		h.v2Pub.Notify(pubsub.ChanV2, &pubsub.V2Initialise{
+			RoomID:      roomID,
+			SnapshotNID: res.SnapshotID,
+		})
 	}
-	h.v2Pub.Notify(pubsub.ChanV2, &pubsub.V2Initialise{
-		RoomID:      roomID,
-		SnapshotNID: res.SnapshotID,
-	})
+	return res.PrependTimelineEvents
 }
 
 func (h *Handler) SetTyping(roomID string, ephEvent json.RawMessage) {

--- a/sync2/poller_test.go
+++ b/sync2/poller_test.go
@@ -460,7 +460,7 @@ type mockDataReceiver struct {
 func (a *mockDataReceiver) Accumulate(userID, roomID, prevBatch string, timeline []json.RawMessage) {
 	a.timelines[roomID] = append(a.timelines[roomID], timeline...)
 }
-func (a *mockDataReceiver) Initialise(roomID string, state []json.RawMessage) {
+func (a *mockDataReceiver) Initialise(roomID string, state []json.RawMessage) []json.RawMessage {
 	a.states[roomID] = state
 	if a.incomingProcess != nil {
 		a.incomingProcess <- struct{}{}
@@ -468,6 +468,9 @@ func (a *mockDataReceiver) Initialise(roomID string, state []json.RawMessage) {
 	if a.unblockProcess != nil {
 		<-a.unblockProcess
 	}
+	// The return value is a list of unknown state events to be prepended to the room
+	// timeline. Untested here---return nil for now.
+	return nil
 }
 func (a *mockDataReceiver) SetTyping(roomID string, ephEvent json.RawMessage) {
 }

--- a/tests-e2e/client_test.go
+++ b/tests-e2e/client_test.go
@@ -251,6 +251,7 @@ func (c *CSAPI) SendEventUnsynced(t *testing.T, roomID string, e Event) string {
 }
 
 // SendEventSynced sends `e` into the room and waits for its event ID to come down /sync.
+// NB: This is specifically v2 sync, not v3 sliding sync!!
 // Returns the event ID of the sent event.
 func (c *CSAPI) SendEventSynced(t *testing.T, roomID string, e Event) string {
 	t.Helper()

--- a/tests-e2e/client_test.go
+++ b/tests-e2e/client_test.go
@@ -236,9 +236,8 @@ func (c *CSAPI) SetRoomAccountData(t *testing.T, roomID, eventType string, conte
 	return c.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "user", c.UserID, "rooms", roomID, "account_data", eventType}, WithJSONBody(t, content))
 }
 
-// SendEventSynced sends `e` into the room and waits for its event ID to come down /sync.
-// Returns the event ID of the sent event.
-func (c *CSAPI) SendEventSynced(t *testing.T, roomID string, e Event) string {
+// SendEventUnsynced sends `e` into the room and returns the event ID of the sent event.
+func (c *CSAPI) SendEventUnsynced(t *testing.T, roomID string, e Event) string {
 	t.Helper()
 	c.txnID++
 	paths := []string{"_matrix", "client", "v3", "rooms", roomID, "send", e.Type, strconv.Itoa(c.txnID)}
@@ -248,6 +247,14 @@ func (c *CSAPI) SendEventSynced(t *testing.T, roomID string, e Event) string {
 	res := c.MustDo(t, "PUT", paths, e.Content)
 	body := ParseJSON(t, res)
 	eventID := GetJSONFieldStr(t, body, "event_id")
+	return eventID
+}
+
+// SendEventSynced sends `e` into the room and waits for its event ID to come down /sync.
+// Returns the event ID of the sent event.
+func (c *CSAPI) SendEventSynced(t *testing.T, roomID string, e Event) string {
+	t.Helper()
+	eventID := c.SendEventUnsynced(t, roomID, e)
 	t.Logf("SendEventSynced waiting for event ID %s", eventID)
 	c.MustSyncUntil(t, SyncReq{}, SyncTimelineHas(roomID, func(r gjson.Result) bool {
 		return r.Get("event_id").Str == eventID
@@ -403,6 +410,61 @@ func (c *CSAPI) RegisterUser(t *testing.T, localpart, password string) (userID, 
 	accessToken = gjson.GetBytes(body, "access_token").Str
 	deviceID = gjson.GetBytes(body, "device_id").Str
 	return userID, accessToken, deviceID
+}
+
+// LoginUser will create a new device for the given user.
+// The new access token and device ID are overwrite those of the current CSAPI instance.
+func (c *CSAPI) Login(t *testing.T, password, deviceID string) {
+	t.Helper()
+	reqBody := map[string]interface{}{
+		"type":     "m.login.password",
+		"password": password,
+		"identifier": map[string]interface{}{
+			"type": "m.id.user",
+			"user": c.UserID,
+		},
+		"device_id": deviceID,
+	}
+	res := c.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "login"}, WithJSONBody(t, reqBody))
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("unable to read response body: %v", err)
+	}
+
+	userID := gjson.GetBytes(body, "user_id").Str
+	if c.UserID != userID {
+		t.Fatalf("Logged in as %s but response included user_id=%s", c.UserID, userID)
+	}
+	gotDeviceID := gjson.GetBytes(body, "device_id").Str
+	if gotDeviceID != deviceID {
+		t.Fatalf("Asked for device ID %s but got %s", deviceID, gotDeviceID)
+	}
+	accessToken := gjson.GetBytes(body, "access_token").Str
+	if c.AccessToken == accessToken {
+		t.Fatalf("Logged in as %s but access token did not change (still %s)", c.UserID, c.AccessToken)
+	}
+
+	c.AccessToken = accessToken
+	c.DeviceID = deviceID
+}
+
+// SetState PUTs a piece of state in a room and returns the event ID of the created state event.
+func (c *CSAPI) SetState(t *testing.T, roomID, eventType, stateKey string, content map[string]interface{}) string {
+	t.Helper()
+	res := c.MustDoFunc(
+		t,
+		"PUT",
+		[]string{"_matrix", "client", "v3", "rooms", roomID, "state", eventType, stateKey},
+		WithJSONBody(t, content),
+	)
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("unable to read response body: %v", err)
+	}
+
+	return gjson.ParseBytes(body).Get("event_id").Str
 }
 
 // RegisterSharedSecret registers a new account with a shared secret via HMAC

--- a/tests-e2e/gappy_state_test.go
+++ b/tests-e2e/gappy_state_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/matrix-org/sliding-sync/sync3"
 	"github.com/matrix-org/sliding-sync/testutils/m"
-	"github.com/tidwall/gjson"
 	"testing"
 )
 
@@ -46,16 +45,7 @@ func TestGappyState(t *testing.T) {
 		m.MatchRoomSubscription(
 			roomID,
 			m.MatchRoomName(firstRoomName),
-			func(r sync3.Room) error {
-				if len(r.Timeline) == 0 {
-					return fmt.Errorf("no/empty timeline in response")
-				}
-				lastReceivedEventID := gjson.ParseBytes(r.Timeline[len(r.Timeline)-1]).Get("event_id").Str
-				if lastReceivedEventID == firstMessageID {
-					return nil
-				}
-				return fmt.Errorf("expected end of timeline to be %s but got %s", firstMessageID, lastReceivedEventID)
-			},
+			MatchRoomTimelineMostRecent(1, []Event{{ID: firstMessageID}}),
 		),
 	)
 
@@ -102,16 +92,7 @@ func TestGappyState(t *testing.T) {
 		m.MatchRoomSubscription(
 			roomID,
 			m.MatchRoomName("potato"),
-			func(r sync3.Room) error {
-				if len(r.Timeline) == 0 {
-					return fmt.Errorf("no timeline in response, expected at least one event")
-				}
-				lastReceivedEventID := gjson.ParseBytes(r.Timeline[len(r.Timeline)-1]).Get("event_id").Str
-				if lastReceivedEventID != latestMessageID {
-					return fmt.Errorf("last message in response is %s, expected %s", lastReceivedEventID, latestMessageID)
-				}
-				return nil
-			},
+			MatchRoomTimelineMostRecent(1, []Event{{ID: latestMessageID}}),
 		),
 	)
 }

--- a/tests-e2e/gappy_state_test.go
+++ b/tests-e2e/gappy_state_test.go
@@ -83,6 +83,9 @@ func TestGappyState(t *testing.T) {
 			roomID,
 			m.MatchRoomName("potato"),
 			func(r sync3.Room) error {
+				if len(r.Timeline) == 0 {
+					return fmt.Errorf("no timeline in response, expected at least one event")
+				}
 				lastReceivedEventID := gjson.ParseBytes(r.Timeline[len(r.Timeline)-1]).Get("event_id").Str
 				if lastReceivedEventID != latestMessageID {
 					return fmt.Errorf("last message in response is %s, expected %s", lastReceivedEventID, latestMessageID)

--- a/tests-e2e/gappy_state_test.go
+++ b/tests-e2e/gappy_state_test.go
@@ -1,0 +1,62 @@
+package syncv3_test
+
+import (
+	"github.com/matrix-org/sliding-sync/sync3"
+	"github.com/matrix-org/sliding-sync/testutils/m"
+	"testing"
+)
+
+func TestGappyState(t *testing.T) {
+	t.Log("Alice registers on the homeserver.")
+	alice := registerNewUser(t)
+
+	t.Log("Alice creates a room")
+	roomID := alice.CreateRoom(t, map[string]interface{}{"preset": "public_chat"})
+
+	t.Log("Alice sends a message into that room")
+	alice.SendEventSynced(t, roomID, Event{
+		Type: "m.room.message",
+		Content: map[string]interface{}{
+			"msgtype": "m.text",
+			"body":    "Hello, world!",
+		},
+	})
+
+	t.Log("Alice logs out of her first device.")
+	alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "logout"})
+
+	t.Log("Alice logs in again on her second device.")
+	alice.Login(t, "password", "device2")
+
+	t.Log("Alice sets two pieces of room state while the proxy isn't polling.")
+	nameContent := map[string]interface{}{"name": "potato"}
+	nameID := alice.SetState(t, roomID, "m.room.name", "", nameContent)
+	powerLevelState := map[string]interface{}{
+		"users":          map[string]int{alice.UserID: 100},
+		"events_default": 10,
+	}
+	powerLevelID := alice.SetState(t, roomID, "m.room.power_levels", "", powerLevelState)
+
+	t.Log("Alice logs out of her second device.")
+	alice.MustDoFunc(t, "POST", []string{"_matrix", "client", "v3", "logout"})
+
+	t.Log("Alice logs in again on her third device.")
+	alice.Login(t, "password", "device3")
+
+	t.Log("Alice does an initial sliding sync.")
+	syncResp := alice.SlidingSync(t,
+		sync3.Request{
+			Lists: map[string]sync3.RequestList{
+				"a": {
+					Ranges: [][2]int64{{0, 20}},
+				},
+			},
+		},
+	)
+
+	t.Log("She should see her latest state events in the response")
+	// TODO: Behind the scenes, this should have created a new poller which did a v2
+	// initial sync. The v2 response should include the full state of the room, which
+	// we should relay in the sync response. Need to express this with a matcher.
+	m.MatchResponse(t, syncResp, m.LogResponse(t))
+}

--- a/tests-integration/poller_test.go
+++ b/tests-integration/poller_test.go
@@ -113,7 +113,10 @@ func TestSecondPollerFiltersToDevice(t *testing.T) {
 	m.MatchResponse(t, res, m.MatchToDeviceMessages([]json.RawMessage{wantMsg}))
 }
 
-// TODO test description
+// Test that the poller makes a best-effort attempt to integrate state seen in a
+// v2 sync state block. Our strategy for doing so is to prepend any unknown state events
+// to the start of the v2 sync response's timeline, which should then be visible to
+// sync v3 clients as ordinary state events in the room timeline.
 func TestPollerHandlesUnknownStateEventsOnIncrementalSync(t *testing.T) {
 	pqString := testutils.PrepareDBConnectionString()
 	v2 := runTestV2Server(t)

--- a/tests-integration/poller_test.go
+++ b/tests-integration/poller_test.go
@@ -221,7 +221,7 @@ func TestPollerUpdatesRoomMemberTrackerOnGappySyncStateBlock(t *testing.T) {
 	v2.queueResponse(aliceToken, sync2.SyncResponse{
 		Rooms: sync2.SyncRoomsResponse{Join: initialJoinBlock},
 	})
-	v2.queueResponse(aliceToken, sync2.SyncResponse{
+	v2.queueResponse(bobToken, sync2.SyncResponse{
 		Rooms: sync2.SyncRoomsResponse{Join: initialJoinBlock},
 	})
 

--- a/tests-integration/poller_test.go
+++ b/tests-integration/poller_test.go
@@ -123,10 +123,9 @@ func TestPollerHandlesUnknownStateEventsOnIncrementalSync(t *testing.T) {
 	v3 := runTestServer(t, v2, pqString)
 	defer v2.close()
 	defer v3.close()
-	deviceAToken := "DEVICE_A_TOKEN"
-	v2.addAccount(alice, deviceAToken)
+	v2.addAccount(alice, aliceToken)
 	const roomID = "!unimportant"
-	v2.queueResponse(deviceAToken, sync2.SyncResponse{
+	v2.queueResponse(aliceToken, sync2.SyncResponse{
 		Rooms: sync2.SyncRoomsResponse{
 			Join: v2JoinTimeline(roomEvents{
 				roomID: roomID,
@@ -134,7 +133,7 @@ func TestPollerHandlesUnknownStateEventsOnIncrementalSync(t *testing.T) {
 			}),
 		},
 	})
-	res := v3.mustDoV3Request(t, deviceAToken, sync3.Request{
+	res := v3.mustDoV3Request(t, aliceToken, sync3.Request{
 		Lists: map[string]sync3.RequestList{
 			"a": {
 				Ranges: [][2]int64{{0, 20}},
@@ -142,7 +141,7 @@ func TestPollerHandlesUnknownStateEventsOnIncrementalSync(t *testing.T) {
 		},
 	})
 
-	t.Log("The poller receives a gappy incremental sync response with a state block")
+	t.Log("The poller receives a gappy incremental sync response with a state block. The power levels and room name have changed.")
 	nameEvent := testutils.NewStateEvent(
 		t,
 		"m.room.name",
@@ -161,7 +160,7 @@ func TestPollerHandlesUnknownStateEventsOnIncrementalSync(t *testing.T) {
 		},
 	)
 	messageEvent := testutils.NewMessageEvent(t, alice, "hello")
-	v2.queueResponse(deviceAToken, sync2.SyncResponse{
+	v2.queueResponse(aliceToken, sync2.SyncResponse{
 		Rooms: sync2.SyncRoomsResponse{
 			Join: map[string]sync2.SyncV2JoinResponse{
 				roomID: {
@@ -178,7 +177,7 @@ func TestPollerHandlesUnknownStateEventsOnIncrementalSync(t *testing.T) {
 		},
 	})
 
-	res = v3.mustDoV3RequestWithPos(t, deviceAToken, res.Pos, sync3.Request{})
+	res = v3.mustDoV3RequestWithPos(t, aliceToken, res.Pos, sync3.Request{})
 	m.MatchResponse(
 		t,
 		res,

--- a/tests-integration/poller_test.go
+++ b/tests-integration/poller_test.go
@@ -167,10 +167,7 @@ func TestPollerHandlesUnknownStateEventsOnIncrementalSync(t *testing.T) {
 		m.MatchRoomSubscription(
 			roomID,
 			m.MatchRoomTimeline([]json.RawMessage{nameEvent, powerLevelsEvent, messageEvent}),
+			m.MatchRoomName("banana"),
 		),
 	)
-}
-
-func eventIDFromRawMessage(message json.RawMessage) string {
-	return gjson.ParseBytes(message).Get("event_id").Str
 }

--- a/tests-integration/v3_test.go
+++ b/tests-integration/v3_test.go
@@ -40,7 +40,12 @@ var (
 	boolTrue = true
 )
 
+// testV2Server is a fake stand-in for the v2 sync API provided by a homeserver.
 type testV2Server struct {
+	// CheckRequest is an arbitrary function which runs after a request has been
+	// received from pollers, but before the resposne is generated. This allows us to
+	// confirm that the proxy is polling the homeserver's v2 sync endpoint in the
+	// manner that we expect.
 	CheckRequest            func(userID, token string, req *http.Request)
 	mu                      *sync.Mutex
 	tokenToUser             map[string]string


### PR DESCRIPTION
Closes #18. This is a best-effort attempt to ensure that room state self-heals after the poller "misses" a state event. We don't attempt to retrieve any missed message events.

For a more robust solution, the homeserver should natively implement sliding sync.

#73 also helps, by making it less likely that the poller sees a gap in the first place.