### PR TITLE
Use setup-go v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
             - uses: actions/checkout@v3
 
             - name: Install Go
-              uses: actions/setup-go@v3
+              uses: actions/setup-go@v4
               with:
                   go-version: 1.19
 
@@ -118,10 +118,12 @@ jobs:
                     --health-retries 5
         steps:
             - uses: actions/checkout@v3
-            - name: "Set Go Version"
-              run: |
-                  echo "$GOROOT_1_19_X64/bin" >> $GITHUB_PATH
-                  echo "~/go/bin" >> $GITHUB_PATH
+
+            - name: Install Go
+              uses: actions/setup-go@v4
+              with:
+                go-version: 1.19
+
             - name: Build
               run: go build ./cmd/syncv3
 


### PR DESCRIPTION
Which claims to automatically cache build products and deps.

(We spend 30 seconds each run downloading and building deps, and I am impatient.)
