### PR TITLE
Associate mxids to requests in Sentry

### DIFF
--- a/internal/context.go
+++ b/internal/context.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"github.com/getsentry/sentry-go"
 
 	"github.com/rs/zerolog"
 )
@@ -43,6 +44,11 @@ func SetRequestContextUserID(ctx context.Context, userID string) {
 	}
 	da := d.(*data)
 	da.userID = userID
+	if hub := sentry.GetHubFromContext(ctx); hub != nil {
+		sentry.ConfigureScope(func(scope *sentry.Scope) {
+			scope.SetUser(sentry.User{Username: userID})
+		})
+	}
 }
 
 func SetRequestContextResponseInfo(


### PR DESCRIPTION
Closes #21. (Or at least, I think this is sufficient to call the sentry support good enough.)

Note the `user` tag at the top here:
![image](https://user-images.githubusercontent.com/8614563/232907392-369c2449-b170-4908-9114-5b965c53661a.png)

Which means that error events should be broken down by mxid:
![image](https://user-images.githubusercontent.com/8614563/232907560-71cd0412-50f4-4f2f-8966-75c59338df37.png)

and should be searchable by mxid:
![image](https://user-images.githubusercontent.com/8614563/232907810-cec04e0a-7f1b-44df-be12-6cffdf777c8e.png)