### PR TITLE
If `bump_event_types` is specified, don't bump for RoomUpdates that aren't RoomEventUpdates.

### DIFF
--- a/sync3/caches/update.go
+++ b/sync3/caches/update.go
@@ -18,6 +18,7 @@ type RoomUpdate interface {
 	UserRoomMetadata() *UserRoomData
 }
 
+// RoomEventUpdate corresponds to a single event seen in a joined room's timeline under sync v2.
 type RoomEventUpdate struct {
 	RoomUpdate
 	EventData *EventData
@@ -27,6 +28,7 @@ func (u *RoomEventUpdate) Type() string {
 	return fmt.Sprintf("RoomEventUpdate[%s]: %v", u.RoomID(), u.EventData.EventType)
 }
 
+// InviteUpdate corresponds to a key-value pair from a v2 sync's `invite` section.
 type InviteUpdate struct {
 	RoomUpdate
 	InviteData InviteData
@@ -36,6 +38,7 @@ func (u *InviteUpdate) Type() string {
 	return fmt.Sprintf("InviteUpdate[%s]", u.RoomID())
 }
 
+// LeftRoomUpdate corresponds to a key-value pair from a v2 sync's `leave` section.
 type LeftRoomUpdate struct {
 	RoomUpdate
 }
@@ -44,6 +47,7 @@ func (u *LeftRoomUpdate) Type() string {
 	return fmt.Sprintf("LeftRoomUpdate[%s]", u.RoomID())
 }
 
+// TypingEdu corresponds to a typing EDU in the `ephemeral` section of a joined room's v2 sync resposne.
 type TypingUpdate struct {
 	RoomUpdate
 }
@@ -52,6 +56,7 @@ func (u *TypingUpdate) Type() string {
 	return fmt.Sprintf("TypingUpdate[%s]", u.RoomID())
 }
 
+// RecieptUpdate corresponds to a receipt EDU in the `ephemeral` section of a joined room's v2 sync resposne.
 type ReceiptUpdate struct {
 	RoomUpdate
 	Receipt internal.Receipt
@@ -61,6 +66,10 @@ func (u *ReceiptUpdate) Type() string {
 	return fmt.Sprintf("ReceiptUpdate[%s]", u.RoomID())
 }
 
+// UnreadCountUpdate represents a change in highlight or notification count change.
+// The current counts are determinted from sync v2 responses; the pollers track
+// changes to those counts to determine if they have decreased, remained unchanged,
+// or increased.
 type UnreadCountUpdate struct {
 	RoomUpdate
 	HasCountDecreased bool
@@ -70,6 +79,7 @@ func (u *UnreadCountUpdate) Type() string {
 	return fmt.Sprintf("UnreadCountUpdate[%s]", u.RoomID())
 }
 
+// AccountDataUpdate represents the (global) `account_data` section of a v2 sync response.
 type AccountDataUpdate struct {
 	AccountData []state.AccountData
 }
@@ -78,6 +88,7 @@ func (u *AccountDataUpdate) Type() string {
 	return fmt.Sprintf("AccountDataUpdate len=%v", len(u.AccountData))
 }
 
+// RoomAccountDataUpdate represents the `account_data` section of joined room's v2 sync response.
 type RoomAccountDataUpdate struct {
 	RoomUpdate
 	AccountData []state.AccountData


### PR DESCRIPTION
Fixes #83.