### PR TITLE
Ensure invites are sent to the client consistently

### DIFF
--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/getsentry/sentry-go"
 	"sync"
+
+	"github.com/getsentry/sentry-go"
 
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/matrix-org/sliding-sync/internal"
@@ -619,6 +620,7 @@ func (c *UserCache) OnInvite(ctx context.Context, roomID string, inviteStateEven
 
 	urd := c.LoadRoomData(roomID)
 	urd.IsInvite = true
+	urd.HasLeft = false
 	urd.HighlightCount = InvitesAreHighlightsValue
 	urd.IsDM = inviteData.IsDM
 	urd.Invite = inviteData


### PR DESCRIPTION
Fixes #66 

The problem is in the way the user cache updates `UserRoomMetadata` in response to certain triggers. It currently says "get me the existing metadata, making one if need be" and then updates fields based on the trigger. This is good but causes problems when resetting fields. The bug in question arose because `IsLeft` was set to true when the user rejected the invite. When the 2nd invite came in, we failed to set `IsLeft=false`. It worked the first time because when we first make the metadata is is set to false