### PR TITLE
OIDC: update sync3 tables

### DIFF
--- a/state/to_device_table.go
+++ b/state/to_device_table.go
@@ -57,7 +57,7 @@ func NewToDeviceTable(db *sqlx.DB) *ToDeviceTable {
 		action SMALLINT DEFAULT 0 -- 0 means unknown
 	);
 	CREATE TABLE IF NOT EXISTS syncv3_to_device_ack_pos (
-	    user_id TEXT NOT NULL,
+		user_id TEXT NOT NULL,
 		device_id TEXT NOT NULL,
 		PRIMARY KEY (user_id, device_id),
 		unack_pos BIGINT NOT NULL

--- a/state/to_device_table.go
+++ b/state/to_device_table.go
@@ -23,6 +23,7 @@ type ToDeviceTable struct {
 
 type ToDeviceRow struct {
 	Position  int64   `db:"position"`
+	UserID    string  `db:"user_id"`
 	DeviceID  string  `db:"device_id"`
 	Message   string  `db:"message"`
 	Type      string  `db:"event_type"`
@@ -46,6 +47,7 @@ func NewToDeviceTable(db *sqlx.DB) *ToDeviceTable {
 	CREATE SEQUENCE IF NOT EXISTS syncv3_to_device_messages_seq;
 	CREATE TABLE IF NOT EXISTS syncv3_to_device_messages (
 		position BIGINT NOT NULL PRIMARY KEY DEFAULT nextval('syncv3_to_device_messages_seq'),
+		user_id TEXT NOT NULL,
 		device_id TEXT NOT NULL,
 		event_type TEXT NOT NULL,
 		sender TEXT NOT NULL,
@@ -55,7 +57,9 @@ func NewToDeviceTable(db *sqlx.DB) *ToDeviceTable {
 		action SMALLINT DEFAULT 0 -- 0 means unknown
 	);
 	CREATE TABLE IF NOT EXISTS syncv3_to_device_ack_pos (
-		device_id TEXT NOT NULL PRIMARY KEY,
+	    user_id TEXT NOT NULL,
+		device_id TEXT NOT NULL,
+		PRIMARY KEY (user_id, device_id),
 		unack_pos BIGINT NOT NULL
 	);
 	CREATE INDEX IF NOT EXISTS syncv3_to_device_messages_device_idx ON syncv3_to_device_messages(device_id);
@@ -65,29 +69,31 @@ func NewToDeviceTable(db *sqlx.DB) *ToDeviceTable {
 	return &ToDeviceTable{db}
 }
 
-func (t *ToDeviceTable) SetUnackedPosition(deviceID string, pos int64) error {
-	_, err := t.db.Exec(`INSERT INTO syncv3_to_device_ack_pos(device_id, unack_pos) VALUES($1,$2) ON CONFLICT (device_id)
-	DO UPDATE SET unack_pos=$2`, deviceID, pos)
+func (t *ToDeviceTable) SetUnackedPosition(userID, deviceID string, pos int64) error {
+	_, err := t.db.Exec(`INSERT INTO syncv3_to_device_ack_pos(user_id, device_id, unack_pos) VALUES($1,$2,$3) ON CONFLICT (user_id, device_id)
+	DO UPDATE SET unack_pos=excluded.unack_pos`, userID, deviceID, pos)
 	return err
 }
 
-func (t *ToDeviceTable) DeleteMessagesUpToAndIncluding(deviceID string, toIncl int64) error {
-	_, err := t.db.Exec(`DELETE FROM syncv3_to_device_messages WHERE device_id = $1 AND position <= $2`, deviceID, toIncl)
+func (t *ToDeviceTable) DeleteMessagesUpToAndIncluding(userID, deviceID string, toIncl int64) error {
+	_, err := t.db.Exec(`DELETE FROM syncv3_to_device_messages WHERE user_id = $1 AND device_id = $2 AND position <= $3`, userID, deviceID, toIncl)
 	return err
 }
 
-func (t *ToDeviceTable) DeleteAllMessagesForDevice(deviceID string) error {
-	_, err := t.db.Exec(`DELETE FROM syncv3_to_device_messages WHERE device_id = $1`, deviceID)
+func (t *ToDeviceTable) DeleteAllMessagesForDevice(userID, deviceID string) error {
+	_, err := t.db.Exec(`DELETE FROM syncv3_to_device_messages WHERE user_id = $1 AND device_id = $2`, userID, deviceID)
 	return err
 }
 
-// Query to-device messages for this device, exclusive of from and inclusive of to. If a to value is unknown, use -1.
-func (t *ToDeviceTable) Messages(deviceID string, from, limit int64) (msgs []json.RawMessage, upTo int64, err error) {
+// Messages fetches up to `limit` to-device messages for this device, starting from and excluding `from`.
+// Returns the fetches messages ordered by ascending position, as well as the position of the last to-device message
+// fetched.
+func (t *ToDeviceTable) Messages(userID, deviceID string, from, limit int64) (msgs []json.RawMessage, upTo int64, err error) {
 	upTo = from
 	var rows []ToDeviceRow
 	err = t.db.Select(&rows,
-		`SELECT position, message FROM syncv3_to_device_messages WHERE device_id = $1 AND position > $2 ORDER BY position ASC LIMIT $3`,
-		deviceID, from, limit,
+		`SELECT position, message FROM syncv3_to_device_messages WHERE user_id = $1 AND device_id = $2 AND position > $3 ORDER BY position ASC LIMIT $4`,
+		userID, deviceID, from, limit,
 	)
 	if len(rows) == 0 {
 		return
@@ -98,18 +104,18 @@ func (t *ToDeviceTable) Messages(deviceID string, from, limit int64) (msgs []jso
 		m := gjson.ParseBytes(msgs[i])
 		msgId := m.Get(`content.org\.matrix\.msgid`).Str
 		if msgId != "" {
-			logger.Info().Str("msgid", msgId).Str("device", deviceID).Msg("ToDeviceTable.Messages")
+			logger.Info().Str("msgid", msgId).Str("user", userID).Str("device", deviceID).Msg("ToDeviceTable.Messages")
 		}
 	}
 	upTo = rows[len(rows)-1].Position
 	return
 }
 
-func (t *ToDeviceTable) InsertMessages(deviceID string, msgs []json.RawMessage) (pos int64, err error) {
+func (t *ToDeviceTable) InsertMessages(userID, deviceID string, msgs []json.RawMessage) (pos int64, err error) {
 	var lastPos int64
 	err = sqlutil.WithTransaction(t.db, func(txn *sqlx.Tx) error {
 		var unackPos int64
-		err = txn.QueryRow(`SELECT unack_pos FROM syncv3_to_device_ack_pos WHERE device_id=$1`, deviceID).Scan(&unackPos)
+		err = txn.QueryRow(`SELECT unack_pos FROM syncv3_to_device_ack_pos WHERE user_id=$1 AND device_id=$2`, userID, deviceID).Scan(&unackPos)
 		if err != nil && err != sql.ErrNoRows {
 			return fmt.Errorf("unable to select unacked pos: %s", err)
 		}
@@ -124,6 +130,7 @@ func (t *ToDeviceTable) InsertMessages(deviceID string, msgs []json.RawMessage) 
 		for i := range msgs {
 			m := gjson.ParseBytes(msgs[i])
 			rows[i] = ToDeviceRow{
+				UserID:   userID,
 				DeviceID: deviceID,
 				Message:  string(msgs[i]),
 				Type:     m.Get("type").Str,
@@ -131,7 +138,7 @@ func (t *ToDeviceTable) InsertMessages(deviceID string, msgs []json.RawMessage) 
 			}
 			msgId := m.Get(`content.org\.matrix\.msgid`).Str
 			if msgId != "" {
-				logger.Debug().Str("msgid", msgId).Str("device", deviceID).Msg("ToDeviceTable.InsertMessages")
+				logger.Debug().Str("msgid", msgId).Str("user", userID).Str("device", deviceID).Msg("ToDeviceTable.InsertMessages")
 			}
 			switch rows[i].Type {
 			case "m.room_key_request":
@@ -155,8 +162,8 @@ func (t *ToDeviceTable) InsertMessages(deviceID string, msgs []json.RawMessage) 
 		if len(cancels) > 0 {
 			var cancelled []string
 			// delete action: request events which have the same unique key, for this device inbox, only if they are not sent to the client already (unacked)
-			err = txn.Select(&cancelled, `DELETE FROM syncv3_to_device_messages WHERE unique_key = ANY($1) AND device_id = $2 AND position > $3 RETURNING unique_key`,
-				pq.StringArray(cancels), deviceID, unackPos)
+			err = txn.Select(&cancelled, `DELETE FROM syncv3_to_device_messages WHERE unique_key = ANY($1) AND user_id = $2 AND device_id = $3 AND position > $4 RETURNING unique_key`,
+				pq.StringArray(cancels), userID, deviceID, unackPos)
 			if err != nil {
 				return fmt.Errorf("failed to delete cancelled events: %s", err)
 			}
@@ -189,10 +196,10 @@ func (t *ToDeviceTable) InsertMessages(deviceID string, msgs []json.RawMessage) 
 			return nil
 		}
 
-		chunks := sqlutil.Chunkify(6, MaxPostgresParameters, ToDeviceRowChunker(rows))
+		chunks := sqlutil.Chunkify(7, MaxPostgresParameters, ToDeviceRowChunker(rows))
 		for _, chunk := range chunks {
-			result, err := txn.NamedQuery(`INSERT INTO syncv3_to_device_messages (device_id, message, event_type, sender, action, unique_key)
-        VALUES (:device_id, :message, :event_type, :sender, :action, :unique_key) RETURNING position`, chunk)
+			result, err := txn.NamedQuery(`INSERT INTO syncv3_to_device_messages (user_id, device_id, message, event_type, sender, action, unique_key)
+        VALUES (:user_id, :device_id, :message, :event_type, :sender, :action, :unique_key) RETURNING position`, chunk)
 			if err != nil {
 				return err
 			}

--- a/state/txn_table.go
+++ b/state/txn_table.go
@@ -8,7 +8,8 @@ import (
 )
 
 type txnRow struct {
-	DeviceID  string `db:"user_id"`
+	UserID    string `db:"user_id"`
+	DeviceID  string `db:"device_id"`
 	EventID   string `db:"event_id"`
 	TxnID     string `db:"txn_id"`
 	Timestamp int64  `db:"ts"`
@@ -22,30 +23,32 @@ func NewTransactionsTable(db *sqlx.DB) *TransactionsTable {
 	// make sure tables are made
 	db.MustExec(`
 	CREATE TABLE IF NOT EXISTS syncv3_txns (
-		user_id TEXT NOT NULL, -- actually device_id
+		user_id TEXT NOT NULL, -- was actually device_id before migration
+		device_id TEXT NOT NULL,
 		event_id TEXT NOT NULL,
 		txn_id TEXT NOT NULL,
 		ts BIGINT NOT NULL,
-		UNIQUE(user_id, event_id)
+		UNIQUE(user_id, device_id, event_id)
 	);
 	`)
 	return &TransactionsTable{db}
 }
 
-func (t *TransactionsTable) Insert(deviceID string, eventIDToTxnID map[string]string) error {
+func (t *TransactionsTable) Insert(userID, deviceID string, eventIDToTxnID map[string]string) error {
 	ts := time.Now()
 	rows := make([]txnRow, 0, len(eventIDToTxnID))
 	for eventID, txnID := range eventIDToTxnID {
 		rows = append(rows, txnRow{
 			EventID:   eventID,
 			TxnID:     txnID,
+			UserID:    userID,
 			DeviceID:  deviceID,
 			Timestamp: ts.UnixMilli(),
 		})
 	}
 	result, err := t.db.NamedQuery(`
-		INSERT INTO syncv3_txns (user_id, event_id, txn_id, ts)
-        VALUES (:user_id, :event_id, :txn_id, :ts)`, rows)
+		INSERT INTO syncv3_txns (user_id, device_id, event_id, txn_id, ts)
+        VALUES (:user_id, :device_id, :event_id, :txn_id, :ts)`, rows)
 	if err == nil {
 		result.Close()
 	}
@@ -57,10 +60,10 @@ func (t *TransactionsTable) Clean(boundaryTime time.Time) error {
 	return err
 }
 
-func (t *TransactionsTable) Select(deviceID string, eventIDs []string) (map[string]string, error) {
+func (t *TransactionsTable) Select(userID, deviceID string, eventIDs []string) (map[string]string, error) {
 	result := make(map[string]string, len(eventIDs))
 	var rows []txnRow
-	err := t.db.Select(&rows, `SELECT event_id, txn_id FROM syncv3_txns WHERE user_id=$1 and event_id=ANY($2)`, deviceID, pq.StringArray(eventIDs))
+	err := t.db.Select(&rows, `SELECT event_id, txn_id FROM syncv3_txns WHERE user_id=$1 AND device_id=$2 and event_id=ANY($3)`, userID, deviceID, pq.StringArray(eventIDs))
 	if err != nil {
 		return nil, err
 	}

--- a/state/txn_table_test.go
+++ b/state/txn_table_test.go
@@ -26,33 +26,34 @@ func TestTransactionTable(t *testing.T) {
 	db, close := connectToDB(t)
 	defer close()
 	userID := "@alice:txns"
+	deviceID := "alice_phone"
 	eventA := "$A"
 	eventB := "$B"
 	txnIDA := "txn_A"
 	txnIDB := "txn_B"
 	table := NewTransactionsTable(db)
 	// empty table select
-	gotTxns, err := table.Select(userID, []string{eventA})
+	gotTxns, err := table.Select(userID, deviceID, []string{eventA})
 	assertNoError(t, err)
 	assertTxns(t, gotTxns, nil)
 
 	// basic insert and select
-	err = table.Insert(userID, map[string]string{
+	err = table.Insert(userID, deviceID, map[string]string{
 		eventA: txnIDA,
 	})
 	assertNoError(t, err)
-	gotTxns, err = table.Select(userID, []string{eventA})
+	gotTxns, err = table.Select(userID, deviceID, []string{eventA})
 	assertNoError(t, err)
 	assertTxns(t, gotTxns, map[string]string{
 		eventA: txnIDA,
 	})
 
 	// multiple txns
-	err = table.Insert(userID, map[string]string{
+	err = table.Insert(userID, deviceID, map[string]string{
 		eventB: txnIDB,
 	})
 	assertNoError(t, err)
-	gotTxns, err = table.Select(userID, []string{eventA, eventB})
+	gotTxns, err = table.Select(userID, deviceID, []string{eventA, eventB})
 	assertNoError(t, err)
 	assertTxns(t, gotTxns, map[string]string{
 		eventA: txnIDA,
@@ -60,14 +61,14 @@ func TestTransactionTable(t *testing.T) {
 	})
 
 	// different user select
-	gotTxns, err = table.Select("@another", []string{eventA, eventB})
+	gotTxns, err = table.Select("@another", "another_device", []string{eventA, eventB})
 	assertNoError(t, err)
 	assertTxns(t, gotTxns, nil)
 
 	// no-op cleanup
 	err = table.Clean(time.Now().Add(-1 * time.Minute))
 	assertNoError(t, err)
-	gotTxns, err = table.Select(userID, []string{eventA, eventB})
+	gotTxns, err = table.Select(userID, deviceID, []string{eventA, eventB})
 	assertNoError(t, err)
 	assertTxns(t, gotTxns, map[string]string{
 		eventA: txnIDA,
@@ -77,7 +78,7 @@ func TestTransactionTable(t *testing.T) {
 	// real cleanup
 	err = table.Clean(time.Now())
 	assertNoError(t, err)
-	gotTxns, err = table.Select(userID, []string{eventA, eventB})
+	gotTxns, err = table.Select(userID, deviceID, []string{eventA, eventB})
 	assertNoError(t, err)
 	assertTxns(t, gotTxns, nil)
 

--- a/sync2/handler2/handler.go
+++ b/sync2/handler2/handler.go
@@ -294,7 +294,7 @@ func (h *Handler) OnReceipt(userID, roomID, ephEventType string, ephEvent json.R
 }
 
 func (h *Handler) AddToDeviceMessages(userID, deviceID string, msgs []json.RawMessage) {
-	_, err := h.Store.ToDeviceTable.InsertMessages(deviceID, msgs)
+	_, err := h.Store.ToDeviceTable.InsertMessages(userID, deviceID, msgs)
 	if err != nil {
 		logger.Err(err).Str("user", userID).Str("device", deviceID).Int("msgs", len(msgs)).Msg("V2: failed to store to-device messages")
 		sentry.CaptureException(err)

--- a/sync2/handler2/handler.go
+++ b/sync2/handler2/handler.go
@@ -206,7 +206,7 @@ func (h *Handler) OnE2EEData(userID, deviceID string, otkCounts map[string]int, 
 	})
 }
 
-func (h *Handler) Accumulate(deviceID, roomID, prevBatch string, timeline []json.RawMessage) {
+func (h *Handler) Accumulate(userID, deviceID, roomID, prevBatch string, timeline []json.RawMessage) {
 	// Remember any transaction IDs that may be unique to this user
 	eventIDToTxnID := make(map[string]string, len(timeline)) // event_id -> txn_id
 	for _, e := range timeline {
@@ -219,9 +219,9 @@ func (h *Handler) Accumulate(deviceID, roomID, prevBatch string, timeline []json
 	}
 	if len(eventIDToTxnID) > 0 {
 		// persist the txn IDs
-		err := h.Store.TransactionsTable.Insert(deviceID, eventIDToTxnID)
+		err := h.Store.TransactionsTable.Insert(userID, deviceID, eventIDToTxnID)
 		if err != nil {
-			logger.Err(err).Str("device", deviceID).Int("num_txns", len(eventIDToTxnID)).Msg("failed to persist txn IDs for user")
+			logger.Err(err).Str("user", userID).Str("device", deviceID).Int("num_txns", len(eventIDToTxnID)).Msg("failed to persist txn IDs for user")
 			sentry.CaptureException(err)
 		}
 	}

--- a/sync2/poller_test.go
+++ b/sync2/poller_test.go
@@ -460,7 +460,7 @@ type mockDataReceiver struct {
 	unblockProcess  chan struct{}
 }
 
-func (a *mockDataReceiver) Accumulate(userID, roomID, prevBatch string, timeline []json.RawMessage) {
+func (a *mockDataReceiver) Accumulate(userID, deviceID, roomID, prevBatch string, timeline []json.RawMessage) {
 	a.timelines[roomID] = append(a.timelines[roomID], timeline...)
 }
 func (a *mockDataReceiver) Initialise(roomID string, state []json.RawMessage) []json.RawMessage {

--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -24,7 +24,7 @@ type CacheFinder interface {
 }
 
 type TransactionIDFetcher interface {
-	TransactionIDForEvents(deviceID string, eventIDs []string) (eventIDToTxnID map[string]string)
+	TransactionIDForEvents(userID, deviceID string, eventIDs []string) (eventIDToTxnID map[string]string)
 }
 
 type UserRoomData struct {
@@ -448,7 +448,7 @@ func (c *UserCache) Invites() map[string]UserRoomData {
 // events are globally scoped, so if Alice sends a message, Bob might receive it first on his v2 loop
 // which would cause the transaction ID to be missing from the event. Instead, we always look for txn
 // IDs in the v2 poller, and then set them appropriately at request time.
-func (c *UserCache) AnnotateWithTransactionIDs(ctx context.Context, deviceID string, roomIDToEvents map[string][]json.RawMessage) map[string][]json.RawMessage {
+func (c *UserCache) AnnotateWithTransactionIDs(ctx context.Context, userID string, deviceID string, roomIDToEvents map[string][]json.RawMessage) map[string][]json.RawMessage {
 	var eventIDs []string
 	eventIDToEvent := make(map[string]struct {
 		roomID string
@@ -467,7 +467,7 @@ func (c *UserCache) AnnotateWithTransactionIDs(ctx context.Context, deviceID str
 			}
 		}
 	}
-	eventIDToTxnID := c.txnIDs.TransactionIDForEvents(deviceID, eventIDs)
+	eventIDToTxnID := c.txnIDs.TransactionIDForEvents(userID, deviceID, eventIDs)
 	for eventID, txnID := range eventIDToTxnID {
 		data, ok := eventIDToEvent[eventID]
 		if !ok {

--- a/sync3/caches/user_test.go
+++ b/sync3/caches/user_test.go
@@ -14,7 +14,7 @@ type txnIDFetcher struct {
 	data map[string]string
 }
 
-func (t *txnIDFetcher) TransactionIDForEvents(deviceID string, eventIDs []string) (eventIDToTxnID map[string]string) {
+func (t *txnIDFetcher) TransactionIDForEvents(userID string, deviceID string, eventIDs []string) (eventIDToTxnID map[string]string) {
 	eventIDToTxnID = make(map[string]string)
 	for _, eventID := range eventIDs {
 		txnID, ok := t.data[eventID]
@@ -83,7 +83,7 @@ func TestAnnotateWithTransactionIDs(t *testing.T) {
 			data: tc.eventIDToTxnIDs,
 		}
 		uc := caches.NewUserCache(userID, nil, nil, fetcher)
-		got := uc.AnnotateWithTransactionIDs(context.Background(), "DEVICE", convertIDToEventStub(tc.roomIDToEvents))
+		got := uc.AnnotateWithTransactionIDs(context.Background(), userID, "DEVICE", convertIDToEventStub(tc.roomIDToEvents))
 		want := convertIDTxnToEventStub(tc.wantRoomIDToEvents)
 		if !reflect.DeepEqual(got, want) {
 			t.Errorf("%s : got %v want %v", tc.name, js(got), js(want))

--- a/sync3/extensions/todevice.go
+++ b/sync3/extensions/todevice.go
@@ -75,7 +75,7 @@ func (r *ToDeviceRequest) ProcessInitial(ctx context.Context, res *Response, ext
 			return
 		}
 		// the client is confirming messages up to `from` so delete everything up to and including it.
-		if err = extCtx.Store.ToDeviceTable.DeleteMessagesUpToAndIncluding(extCtx.DeviceID, from); err != nil {
+		if err = extCtx.Store.ToDeviceTable.DeleteMessagesUpToAndIncluding(extCtx.UserID, extCtx.DeviceID, from); err != nil {
 			l.Err(err).Str("since", r.Since).Msg("failed to delete to-device messages up to this value")
 			// TODO add context to sentry
 			internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(err)
@@ -94,14 +94,14 @@ func (r *ToDeviceRequest) ProcessInitial(ctx context.Context, res *Response, ext
 		internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(fmt.Errorf(errMsg))
 	}
 
-	msgs, upTo, err := extCtx.Store.ToDeviceTable.Messages(extCtx.DeviceID, from, int64(r.Limit))
+	msgs, upTo, err := extCtx.Store.ToDeviceTable.Messages(extCtx.UserID, extCtx.DeviceID, from, int64(r.Limit))
 	if err != nil {
 		l.Err(err).Int64("from", from).Msg("cannot query to-device messages")
 		// TODO add context to sentry
 		internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(err)
 		return
 	}
-	err = extCtx.Store.ToDeviceTable.SetUnackedPosition(extCtx.DeviceID, upTo)
+	err = extCtx.Store.ToDeviceTable.SetUnackedPosition(extCtx.UserID, extCtx.DeviceID, upTo)
 	if err != nil {
 		l.Err(err).Msg("cannot set unacked position")
 		// TODO add context to sentry

--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -458,7 +458,7 @@ func (s *ConnState) getInitialRoomData(ctx context.Context, roomSub sync3.RoomSu
 		roomToUsersInTimeline[roomID] = userIDs
 		roomToTimeline[roomID] = urd.Timeline
 	}
-	roomToTimeline = s.userCache.AnnotateWithTransactionIDs(ctx, s.deviceID, roomToTimeline)
+	roomToTimeline = s.userCache.AnnotateWithTransactionIDs(ctx, s.userID, s.deviceID, roomToTimeline)
 	rsm := roomSub.RequiredStateMap(s.userID)
 	roomIDToState := s.globalCache.LoadRoomState(ctx, roomIDs, s.loadPosition, rsm, roomToUsersInTimeline)
 	if roomIDToState == nil { // e.g no required_state

--- a/sync3/handler/connstate_live.go
+++ b/sync3/handler/connstate_live.go
@@ -210,7 +210,7 @@ func (s *connStateLive) processLiveUpdate(ctx context.Context, up caches.Update,
 			// - the initial:true room from BuildSubscriptions contains the latest live events in the timeline as it's pulled from the DB
 			// - we then process the live events in turn which adds them again.
 			if !advancedPastEvent {
-				roomIDtoTimeline := s.userCache.AnnotateWithTransactionIDs(ctx, s.deviceID, map[string][]json.RawMessage{
+				roomIDtoTimeline := s.userCache.AnnotateWithTransactionIDs(ctx, s.userID, s.deviceID, map[string][]json.RawMessage{
 					roomEventUpdate.RoomID(): {roomEventUpdate.EventData.Event},
 				})
 				r.Timeline = append(r.Timeline, roomIDtoTimeline[roomEventUpdate.RoomID()]...)

--- a/sync3/handler/connstate_test.go
+++ b/sync3/handler/connstate_test.go
@@ -33,7 +33,7 @@ func (t *NopJoinTracker) IsUserJoined(userID, roomID string) bool {
 
 type NopTransactionFetcher struct{}
 
-func (t *NopTransactionFetcher) TransactionIDForEvents(userID string, eventID []string) (eventIDToTxnID map[string]string) {
+func (t *NopTransactionFetcher) TransactionIDForEvents(userID, deviceID string, eventIDs []string) (eventIDToTxnID map[string]string) {
 	return
 }
 

--- a/sync3/handler/handler.go
+++ b/sync3/handler/handler.go
@@ -533,8 +533,8 @@ func (h *SyncLiveHandler) DeviceData(ctx context.Context, userID, deviceID strin
 }
 
 // Implements TransactionIDFetcher
-func (h *SyncLiveHandler) TransactionIDForEvents(deviceID string, eventIDs []string) (eventIDToTxnID map[string]string) {
-	eventIDToTxnID, err := h.Storage.TransactionsTable.Select(deviceID, eventIDs)
+func (h *SyncLiveHandler) TransactionIDForEvents(userID string, deviceID string, eventIDs []string) (eventIDToTxnID map[string]string) {
+	eventIDToTxnID, err := h.Storage.TransactionsTable.Select(userID, deviceID, eventIDs)
 	if err != nil {
 		logger.Warn().Str("err", err.Error()).Str("device", deviceID).Msg("failed to select txn IDs for events")
 	}


### PR DESCRIPTION
Part 2 of N, per https://github.com/matrix-org/sliding-sync/issues/89#issuecomment-1527909808.

This changes the remaining database tables so that any per-device data is associated with a (user_id, device_id) pair.

The next step will be to write migration logic.