### PR TITLE
Migrate existing data to new schema on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
   GIT_COMMIT=$(git rev-list -1 HEAD) && \
-  go build -ldflags "-X main.GitCommit=$GIT_COMMIT" -trimpath -o /out/ "./cmd/$BINARYNAME"
+  go build -ldflags "-X main.GitCommit=$GIT_COMMIT" -trimpath -o /out/syncv3 "./cmd/$BINARYNAME"
 
 FROM alpine:3.17
 
@@ -19,4 +19,7 @@ ENV SYNCV3_BINDADDR="0.0.0.0:8008"
 EXPOSE 8008
 
 WORKDIR /usr/bin
+# It would be nice if the binary we exec was called $BINARYNAME here, but build args
+# aren't expanded in ENTRYPOINT directives. Instead, we always call the output binary
+# "syncv3". (See https://github.com/moby/moby/issues/18492)
 ENTRYPOINT /usr/bin/syncv3

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,12 @@ FROM docker.io/golang:1.19-alpine AS base
 WORKDIR /build
 
 RUN apk --update --no-cache add build-base git
+ARG BINARYNAME=syncv3
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
   GIT_COMMIT=$(git rev-list -1 HEAD) && \
-  go build -ldflags "-X main.GitCommit=$GIT_COMMIT" -trimpath -o /out/ ./cmd/syncv3
+  go build -ldflags "-X main.GitCommit=$GIT_COMMIT" -trimpath -o /out/ "./cmd/$BINARYNAME"
 
 FROM alpine:3.17
 

--- a/cmd/syncv3/main.go
+++ b/cmd/syncv3/main.go
@@ -131,6 +131,11 @@ func main() {
 		}
 	}
 
+	err := sync2.MigrateDeviceIDs(args[EnvServer], args[EnvDB], args[EnvSecret], true)
+	if err != nil {
+		panic(err)
+	}
+
 	h2, h3 := syncv3.Setup(args[EnvServer], args[EnvDB], args[EnvSecret], syncv3.Opts{
 		Debug:                args[EnvDebug] == "1",
 		AddPrometheusMetrics: args[EnvPrometheus] != "",

--- a/cmd/testmigration/main.go
+++ b/cmd/testmigration/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"github.com/jmoiron/sqlx"
+	"github.com/matrix-org/sliding-sync/sync2"
+	"net/http"
+	"os"
+	"time"
+)
+
+const (
+	// Required fields
+	EnvServer = "SYNCV3_SERVER"
+	EnvDB     = "SYNCV3_DB"
+	EnvSecret = "SYNCV3_SECRET"
+
+	// Migration test only
+	EnvMigrationCommit = "SYNCV3_TEST_MIGRATION_COMMIT"
+)
+
+func main() {
+	args := map[string]string{
+		EnvServer:          os.Getenv(EnvServer),
+		EnvDB:              os.Getenv(EnvDB),
+		EnvSecret:          os.Getenv(EnvSecret),
+		EnvMigrationCommit: os.Getenv(EnvMigrationCommit),
+	}
+
+	db, err := sqlx.Open("postgres", args[EnvDB])
+	if err != nil {
+		panic(err)
+	}
+
+	v2Client := &sync2.HTTPClient{
+		Client: &http.Client{
+			Timeout: 5 * time.Minute,
+		},
+		DestinationServer: args[EnvServer],
+	}
+
+	err = sync2.MigrateDeviceIDs(db, args[EnvDB], v2Client, args[EnvMigrationCommit] != "")
+	if err != nil {
+		panic(err)
+	}
+}

--- a/cmd/testmigration/main.go
+++ b/cmd/testmigration/main.go
@@ -38,7 +38,7 @@ func main() {
 		DestinationServer: args[EnvServer],
 	}
 
-	err = sync2.MigrateDeviceIDs(db, args[EnvDB], v2Client, args[EnvMigrationCommit] != "")
+	err = sync2.MigrateDeviceIDs(db, args[EnvSecret], v2Client, args[EnvMigrationCommit] != "")
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/testmigration/main.go
+++ b/cmd/testmigration/main.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"github.com/jmoiron/sqlx"
 	"github.com/matrix-org/sliding-sync/sync2"
-	"net/http"
 	"os"
-	"time"
 )
 
 const (
@@ -26,19 +23,7 @@ func main() {
 		EnvMigrationCommit: os.Getenv(EnvMigrationCommit),
 	}
 
-	db, err := sqlx.Open("postgres", args[EnvDB])
-	if err != nil {
-		panic(err)
-	}
-
-	v2Client := &sync2.HTTPClient{
-		Client: &http.Client{
-			Timeout: 5 * time.Minute,
-		},
-		DestinationServer: args[EnvServer],
-	}
-
-	err = sync2.MigrateDeviceIDs(db, args[EnvSecret], v2Client, args[EnvMigrationCommit] != "")
+	err := sync2.MigrateDeviceIDs(args[EnvServer], args[EnvDB], args[EnvSecret], args[EnvMigrationCommit] != "")
 	if err != nil {
 		panic(err)
 	}

--- a/state/to_device_table.go
+++ b/state/to_device_table.go
@@ -81,7 +81,12 @@ func (t *ToDeviceTable) DeleteMessagesUpToAndIncluding(userID, deviceID string, 
 }
 
 func (t *ToDeviceTable) DeleteAllMessagesForDevice(userID, deviceID string) error {
+	// TODO: should these deletes take place in a transaction?
 	_, err := t.db.Exec(`DELETE FROM syncv3_to_device_messages WHERE user_id = $1 AND device_id = $2`, userID, deviceID)
+	if err != nil {
+		return err
+	}
+	_, err = t.db.Exec(`DELETE FROM syncv3_to_device_ack_pos WHERE user_id = $1 AND device_id = $2`, userID, deviceID)
 	return err
 }
 

--- a/state/txn_table.go
+++ b/state/txn_table.go
@@ -23,7 +23,7 @@ func NewTransactionsTable(db *sqlx.DB) *TransactionsTable {
 	// make sure tables are made
 	db.MustExec(`
 	CREATE TABLE IF NOT EXISTS syncv3_txns (
-		user_id TEXT NOT NULL, -- was actually device_id before migration
+		user_id TEXT NOT NULL,
 		device_id TEXT NOT NULL,
 		event_id TEXT NOT NULL,
 		txn_id TEXT NOT NULL,

--- a/sync2/migration.go
+++ b/sync2/migration.go
@@ -55,7 +55,7 @@ func isMigrated(txn *sqlx.Tx) (migrated bool, err error) {
 	err = txn.QueryRow(`
 		SELECT EXISTS(
 		    SELECT 1 FROM information_schema.columns
-			WHERE table_name = 'syncv3_sync2_devices' AND column_name = 'user_id'
+			WHERE table_name = 'syncv3_txns' AND column_name = 'user_id'
 		);
 	`).Scan(&migrated)
 

--- a/sync2/migration.go
+++ b/sync2/migration.go
@@ -136,6 +136,10 @@ func runMigration(txn *sqlx.Tx, secret string, whoamiClient Client) error {
 		}
 		logger.Info().Msgf("%4d/%4d migrating device %s", i+1, len(devices), device.AccessTokenHash)
 		err = migrateDevice(txn, whoamiClient, &device)
+		if err == HTTP401 {
+			logger.Warn().Msgf("runMigration: device %s has already expired", device.AccessTokenHash)
+			panic("TODO handle expired tokens")
+		}
 		if err != nil {
 			logger.Err(err).Msgf("runMigration: failed to migrate device %s", device.AccessTokenHash)
 			numErrors++

--- a/sync2/migration.go
+++ b/sync2/migration.go
@@ -23,7 +23,7 @@ func MigrateDeviceIDs(db *sqlx.DB, secret string, whoamiClient Client, commit bo
 			logger.Debug().Msg("MigrateDeviceIDs: migration has already taken place")
 			return nil
 		}
-		logger.Info().Msg("MigrateDeviceIDs: starting")
+		logger.Info().Msgf("MigrateDeviceIDs: starting (commit=%t)", commit)
 
 		err = alterTables(txn)
 		if err != nil {

--- a/sync2/migration.go
+++ b/sync2/migration.go
@@ -1,0 +1,177 @@
+package sync2
+
+import (
+	"fmt"
+	"github.com/jmoiron/sqlx"
+	"github.com/matrix-org/sliding-sync/sqlutil"
+)
+
+func MigrateDeviceIDs(db *sqlx.DB, whoamiClient Client, commit bool) error {
+	return sqlutil.WithTransaction(db, func(txn *sqlx.Tx) (err error) {
+		migrated, err := isMigrated(txn)
+		if err != nil {
+			return
+		}
+		if migrated {
+			logger.Debug().Msg("MigrateDeviceIDs: migration has already taken place.")
+		}
+
+		err = alterTables(txn)
+		if err != nil {
+			return
+		}
+
+		err = runMigration(txn, whoamiClient)
+		if err != nil {
+			return
+		}
+		err = finish(txn)
+		if err != nil {
+			return
+		}
+
+		if !commit {
+			err = fmt.Errorf("MigrateDeviceIDs: migration succeeded without errors, but commit is false - rolling back anyway")
+		} else {
+			logger.Info().Msg("MigrateDeviceIDs: migration succeeded - committing")
+		}
+		return
+	})
+}
+
+func isMigrated(txn *sqlx.Tx) (migrated bool, err error) {
+	err = txn.QueryRow(`
+		SELECT EXISTS(
+		    SELECT 1 FROM information_schema.columns
+			WHERE table_name = 'syncv3_sync2_devices' AND column_name = 'user_id'
+		);
+	`).Scan(&migrated)
+
+	if err != nil {
+		err = fmt.Errorf("checkNotMigrated failed: %s", err)
+	}
+	return
+}
+
+func alterTables(txn *sqlx.Tx) (err error) {
+	_, err = txn.Exec(`
+		ALTER TABLE syncv3_sync2_devices
+		DROP CONSTRAINT syncv3_sync2_devices_pkey;
+	`)
+	if err != nil {
+		return
+	}
+
+	_, err = txn.Exec(`
+		ALTER TABLE syncv3_to_device_messages
+		DROP CONSTRAINT syncv3_to_device_messages_pkey,
+		ADD COLUMN user_id TEXT;
+	`)
+	if err != nil {
+		return
+	}
+
+	_, err = txn.Exec(`
+		ALTER TABLE syncv3_to_device_ack_pos
+		DROP CONSTRAINT syncv3_to_device_ack_pos_pkey,
+		ADD COLUMN user_id TEXT;
+	`)
+	if err != nil {
+		return
+	}
+
+	_, err = txn.Exec(`
+		ALTER TABLE syncv3_txns
+		DROP CONSTRAINT syncv3_txns_user_id_event_id_key,
+		ADD COLUMN user_id TEXT;
+	`)
+
+	return
+}
+
+type oldDevice struct {
+	AccessToken          string
+	AccessTokenHash      string `db:"device_id"`
+	UserID               string `db:"user_id"`
+	AccessTokenEncrypted string `db:"v2_token_encrypted"`
+	Since                string `db:"since"`
+}
+
+func runMigration(txn *sqlx.Tx, whoamiClient Client) (err error) {
+
+	logger.Info().Msg("Loading old-style devices into memory")
+	var devices []oldDevice
+	err = txn.Select(
+		&devices,
+		`SELECT device_id, user_id, v2_token_encrypted, since FROM syncv3_sync2_devices;`,
+	)
+	if err != nil {
+		return
+	}
+
+	logger.Info().Msgf("Got %s devices to migrate", len(devices))
+	for _, device := range devices {
+		err = migrateDevice(txn, whoamiClient, &device)
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}
+
+func migrateDevice(txn *sqlx.Tx, whoamiClient Client, device *oldDevice) (err error) {
+	// Migration is required. Fetch the "real" device ID.
+	gotUserID, gotHSDeviceID, err := whoamiClient.WhoAmI(device.)
+	if err != nil {
+		return err
+	}
+	// Sanity check the user ID from the HS matches our records
+	if gotUserID != d.UserID {
+		return fmt.Errorf(
+			"/whoami response was for the wrong user. Queried for %s, but got response for %s",
+			d.UserID, gotUserID,
+		)
+	}
+	return
+}
+
+func finish(txn *sqlx.Tx) (err error) {
+	_, err = txn.Exec(`
+		ALTER TABLE syncv3_sync2_devices
+		DROP COLUMN v2_token_encrypted,
+		ADD PRIMARY KEY (user_id, device_id);
+	`)
+	if err != nil {
+		return
+	}
+
+	_, err = txn.Exec(`
+		ALTER TABLE syncv3_to_device_messages
+		ALTER COLUMN user_id SET NOT NULL,
+		ADD PRIMARY KEY (user_id, device_id);
+	`)
+	if err != nil {
+		return
+	}
+
+	_, err = txn.Exec(`
+		ALTER TABLE syncv3_to_device_ack_pos
+		ALTER COLUMN user_id SET NOT NULL,
+		ADD PRIMARY KEY (user_id, device_id);
+	`)
+	if err != nil {
+		return
+	}
+
+	_, err = txn.Exec(`
+		ALTER TABLE syncv3_txns
+		ALTER COLUMN device_id SET NOT NULL,
+		ADD UNIQUE(user_id, device_id, event_id);
+	`)
+	if err != nil {
+		return
+	}
+
+	return
+}

--- a/sync2/migration.go
+++ b/sync2/migration.go
@@ -73,8 +73,8 @@ func MigrateDeviceIDs(destHomeserver, postgresURI, secret string, commit bool) e
 
 func isMigrated(txn *sqlx.Tx) (bool, error) {
 	// Keep this dead simple for now. This is a one-off migration, before version 1.0.
-	// In the future we'll rip this out and tell people that it's the job to ensure this
-	// migration has run before they upgrade beyond the rip-out point.
+	// In the future we'll rip this out and tell people that it's their job to ensure
+	// this migration has run before they upgrade beyond the rip-out point.
 
 	// We're going to detect if the migration has run by testing for the existence of
 	// a column added by the migration. First, check that the table exists.
@@ -82,7 +82,7 @@ func isMigrated(txn *sqlx.Tx) (bool, error) {
 	err := txn.QueryRow(`
 		SELECT EXISTS(
 		    SELECT 1 FROM information_schema.columns
-			WHERE table_name = 'syncv3_txns' AND column_name = 'device_id'
+			WHERE table_name = 'syncv3_txns'
 		);
 	`).Scan(&tableExists)
 	if err != nil {
@@ -91,6 +91,7 @@ func isMigrated(txn *sqlx.Tx) (bool, error) {
 	if !tableExists {
 		// The proxy has never been run before and its tables have never been created.
 		// We do not need to run the migration.
+		logger.Debug().Msg("isMigrated: no syncv3_txns table, no migration needed")
 		return true, nil
 	}
 

--- a/sync2/migration.go
+++ b/sync2/migration.go
@@ -259,7 +259,7 @@ func cleanupDevice(txn *sqlx.Tx, device *oldDevice) (err error) {
 	err = exec(
 		txn,
 		`DELETE FROM syncv3_to_device_ack_pos WHERE device_id = $1`,
-		expectAnyNumberOfRowsAffected,
+		expectAtMostOneRowAffected,
 		device.AccessTokenHash,
 	)
 	if err != nil {
@@ -269,6 +269,16 @@ func cleanupDevice(txn *sqlx.Tx, device *oldDevice) (err error) {
 	err = exec(
 		txn,
 		`DELETE FROM syncv3_device_data WHERE device_id = $1`,
+		expectAtMostOneRowAffected,
+		device.AccessTokenHash,
+	)
+	if err != nil {
+		return
+	}
+
+	err = exec(
+		txn,
+		`DELETE FROM syncv3_txns WHERE user_id = $1`,
 		expectAnyNumberOfRowsAffected,
 		device.AccessTokenHash,
 	)

--- a/sync2/migration.go
+++ b/sync2/migration.go
@@ -55,7 +55,7 @@ func isMigrated(txn *sqlx.Tx) (migrated bool, err error) {
 	err = txn.QueryRow(`
 		SELECT EXISTS(
 		    SELECT 1 FROM information_schema.columns
-			WHERE table_name = 'syncv3_txns' AND column_name = 'user_id'
+			WHERE table_name = 'syncv3_txns' AND column_name = 'device_id'
 		);
 	`).Scan(&migrated)
 
@@ -95,7 +95,7 @@ func alterTables(txn *sqlx.Tx) (err error) {
 	_, err = txn.Exec(`
 		ALTER TABLE syncv3_txns
 		DROP CONSTRAINT syncv3_txns_user_id_event_id_key,
-		ADD COLUMN user_id TEXT;
+		ADD COLUMN device_id TEXT;
 	`)
 
 	return

--- a/sync2/migration.go
+++ b/sync2/migration.go
@@ -76,7 +76,6 @@ func alterTables(txn *sqlx.Tx) (err error) {
 
 	_, err = txn.Exec(`
 		ALTER TABLE syncv3_to_device_messages
-		DROP CONSTRAINT syncv3_to_device_messages_pkey,
 		ADD COLUMN user_id TEXT;
 	`)
 	if err != nil {
@@ -264,8 +263,7 @@ func finish(txn *sqlx.Tx) (err error) {
 
 	_, err = txn.Exec(`
 		ALTER TABLE syncv3_to_device_messages
-		ALTER COLUMN user_id SET NOT NULL,
-		ADD PRIMARY KEY (user_id, device_id);
+		ALTER COLUMN user_id SET NOT NULL;
 	`)
 	if err != nil {
 		return

--- a/sync2/migration_test.go
+++ b/sync2/migration_test.go
@@ -1,0 +1,27 @@
+package sync2
+
+import (
+	"github.com/jmoiron/sqlx"
+	"github.com/matrix-org/sliding-sync/sqlutil"
+	"github.com/matrix-org/sliding-sync/state"
+	"testing"
+)
+
+func TestNewSchemaIsConsideredMigrated(t *testing.T) {
+	NewStore(postgresConnectionString, "my_secret")
+	state.NewStorage(postgresConnectionString)
+
+	db, close := connectToDB(t)
+	defer close()
+	var migrated bool
+	err := sqlutil.WithTransaction(db, func(txn *sqlx.Tx) (err error) {
+		migrated, err = isMigrated(txn)
+		return
+	})
+	if err != nil {
+		t.Fatalf("Error calling isMigrated: %s", err)
+	}
+	if !migrated {
+		t.Fatalf("Expected a new DB to be considered migrated, but it was not")
+	}
+}

--- a/sync2/migration_test.go
+++ b/sync2/migration_test.go
@@ -7,6 +7,29 @@ import (
 	"testing"
 )
 
+func TestConsideredMigratedOnFirstStartup(t *testing.T) {
+	db, close := connectToDB(t)
+	defer close()
+	var migrated bool
+	err := sqlutil.WithTransaction(db, func(txn *sqlx.Tx) (err error) {
+		// Attempt to make this test independent of others by dropping the table whose
+		// columns we probe.
+		_, err = txn.Exec("DROP TABLE IF EXISTS syncv3_txns;")
+		if err != nil {
+			return err
+		}
+		migrated, err = isMigrated(txn)
+		return
+	})
+
+	if err != nil {
+		t.Fatalf("Error calling isMigrated: %s", err)
+	}
+	if !migrated {
+		t.Fatalf("Expected a non-existent DB to be considered migrated, but it was not")
+	}
+}
+
 func TestNewSchemaIsConsideredMigrated(t *testing.T) {
 	NewStore(postgresConnectionString, "my_secret")
 	state.NewStorage(postgresConnectionString)

--- a/sync2/tokens_table.go
+++ b/sync2/tokens_table.go
@@ -71,6 +71,11 @@ func (t *TokensTable) encrypt(token string) string {
 	return hex.EncodeToString(nonce) + " " + hex.EncodeToString(gcm.Seal(nil, nonce, []byte(token), nil))
 }
 func (t *TokensTable) decrypt(nonceAndEncToken string) (string, error) {
+	return decrypt(nonceAndEncToken, t.key256)
+}
+
+// Pulled out to a free function to use in the device ID migration.
+func decrypt(nonceAndEncToken string, key []byte) (string, error) {
 	segs := strings.Split(nonceAndEncToken, " ")
 	nonce := segs[0]
 	nonceBytes, err := hex.DecodeString(nonce)
@@ -82,7 +87,7 @@ func (t *TokensTable) decrypt(nonceAndEncToken string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("decrypt token: failed to decode hex: %s", err)
 	}
-	block, err := aes.NewCipher(t.key256)
+	block, err := aes.NewCipher(key)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Tested sucessfully against an isolated backup of the m.org proxy deployment. (Circa 5 minutes to run and commit.)

I would like to write a few test cases (see https://github.com/matrix-org/sliding-sync/issues/89#issuecomment-1527909808) before closing #89 and #51.