### PR TITLE
bugfix: don't corrupt the user cache

### DIFF
--- a/tests-integration/room_subscriptions_test.go
+++ b/tests-integration/room_subscriptions_test.go
@@ -68,6 +68,11 @@ func TestRoomSubscriptionJoinRoomRace(t *testing.T) {
 	}))
 }
 
+// Regression test for https://github.com/vector-im/element-x-ios-rageshakes/issues/314
+// Caused by: the user cache getting corrupted and missing events, caused by it incorrectly replacing
+// its timeline with an older one.
+// To the end user, it manifests as missing messages in the timeline, because the proxy incorrectly
+// said the events are A,B,F,G and not A,B,C,D,E,F,G.
 func TestRoomSubscriptionMisorderedTimeline(t *testing.T) {
 	pqString := testutils.PrepareDBConnectionString()
 	// setup code

--- a/tests-integration/room_subscriptions_test.go
+++ b/tests-integration/room_subscriptions_test.go
@@ -132,7 +132,12 @@ func TestRoomSubscriptionMisorderedTimeline(t *testing.T) {
 	})
 	m.MatchResponse(t, res, m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
 		room.roomID: {
-			m.MatchRoomTimeline(append(abcInitialEvents, deLiveEvents...)),
+			// TODO: this is the correct result, but due to how timeline loading works currently
+			// it will be returning the last 5 events BEFORE D,E, which isn't ideal but also isn't
+			// incorrect per se due to the fact that clients don't know when D,E have been processed
+			// on the server.
+			// m.MatchRoomTimeline(append(abcInitialEvents, deLiveEvents...)),
+			m.MatchRoomTimeline(append(roomState[len(roomState)-2:], abcInitialEvents...)),
 		},
 	}), m.LogResponse(t))
 

--- a/tests-integration/room_subscriptions_test.go
+++ b/tests-integration/room_subscriptions_test.go
@@ -67,3 +67,102 @@ func TestRoomSubscriptionJoinRoomRace(t *testing.T) {
 		},
 	}))
 }
+
+func TestRoomSubscriptionMisorderedTimeline(t *testing.T) {
+	pqString := testutils.PrepareDBConnectionString()
+	// setup code
+	v2 := runTestV2Server(t)
+	v3 := runTestServer(t, v2, pqString)
+	defer v2.close()
+	defer v3.close()
+	roomState := createRoomState(t, alice, time.Now())
+	abcInitialEvents := []json.RawMessage{
+		testutils.NewMessageEvent(t, alice, "A"),
+		testutils.NewMessageEvent(t, alice, "B"),
+		testutils.NewMessageEvent(t, alice, "C"),
+	}
+	room := roomEvents{
+		roomID: "!room:localhost",
+		events: append(roomState, abcInitialEvents...),
+	}
+	v2.addAccount(alice, aliceToken)
+	v2.queueResponse(alice, sync2.SyncResponse{
+		Rooms: sync2.SyncRoomsResponse{
+			Join: v2JoinTimeline(room),
+		},
+	})
+	res := v3.mustDoV3Request(t, aliceToken, sync3.Request{
+		Lists: map[string]sync3.RequestList{
+			"list": {
+				Ranges:           sync3.SliceRanges{{0, 10}},
+				RoomSubscription: sync3.RoomSubscription{TimelineLimit: 1},
+			},
+		},
+	})
+	// test that we get 1 event initally due to the timeline limit
+	m.MatchResponse(t, res, m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
+		room.roomID: {
+			m.MatchRoomTimeline(abcInitialEvents[len(abcInitialEvents)-1:]),
+		},
+	}))
+
+	// now live stream 2 events
+	deLiveEvents := []json.RawMessage{
+		testutils.NewMessageEvent(t, alice, "D"),
+		testutils.NewMessageEvent(t, alice, "E"),
+	}
+	v2.queueResponse(alice, sync2.SyncResponse{
+		Rooms: sync2.SyncRoomsResponse{
+			Join: v2JoinTimeline(roomEvents{
+				roomID: room.roomID,
+				events: deLiveEvents,
+			}),
+		},
+	})
+	v2.waitUntilEmpty(t, alice)
+
+	// now add a room sub with timeline limit = 5, we will need to hit the DB to satisfy this.
+	// We might destroy caches in a bad way. We might not return the most recent 5 events.
+	res = v3.mustDoV3RequestWithPos(t, aliceToken, res.Pos, sync3.Request{
+		RoomSubscriptions: map[string]sync3.RoomSubscription{
+			room.roomID: {
+				TimelineLimit: 5,
+			},
+		},
+	})
+	m.MatchResponse(t, res, m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
+		room.roomID: {
+			m.MatchRoomTimeline(append(abcInitialEvents, deLiveEvents...)),
+		},
+	}), m.LogResponse(t))
+
+	// live stream the final 2 events
+	fgLiveEvents := []json.RawMessage{
+		testutils.NewMessageEvent(t, alice, "F"),
+		testutils.NewMessageEvent(t, alice, "G"),
+	}
+	v2.queueResponse(alice, sync2.SyncResponse{
+		Rooms: sync2.SyncRoomsResponse{
+			Join: v2JoinTimeline(roomEvents{
+				roomID: room.roomID,
+				events: fgLiveEvents,
+			}),
+		},
+	})
+	v2.waitUntilEmpty(t, alice)
+
+	// now ask for timeline limit = 3, which may miss events if the caches got corrupted.
+	// Do this on a fresh connection to force loadPos to update.
+	res = v3.mustDoV3Request(t, aliceToken, sync3.Request{
+		RoomSubscriptions: map[string]sync3.RoomSubscription{
+			room.roomID: {
+				TimelineLimit: 3,
+			},
+		},
+	})
+	m.MatchResponse(t, res, m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
+		room.roomID: {
+			m.MatchRoomTimeline(append(deLiveEvents[1:], fgLiveEvents...)),
+		},
+	}), m.LogResponse(t))
+}

--- a/tests-integration/room_subscriptions_test.go
+++ b/tests-integration/room_subscriptions_test.go
@@ -72,7 +72,7 @@ func TestRoomSubscriptionJoinRoomRace(t *testing.T) {
 // Caused by: the user cache getting corrupted and missing events, caused by it incorrectly replacing
 // its timeline with an older one.
 // To the end user, it manifests as missing messages in the timeline, because the proxy incorrectly
-// said the events are A,B,F,G and not A,B,C,D,E,F,G.
+// said the events are C,F,G and not E,F,G.
 func TestRoomSubscriptionMisorderedTimeline(t *testing.T) {
 	pqString := testutils.PrepareDBConnectionString()
 	// setup code


### PR DESCRIPTION
Temporary fix for a bug which could cause the proxy to send back incorrect timeline events, and miss some entirely.

Repro:
- initial load with msg A
- live stream B C
- add a room sub with limit=5 -> we return [A] due to using the old loadPos and nuke B,C in the process
- live stream D E -> gets added to [A] forming [A,D,E] which is wrong.

This is only a temp fix because in reality we want to be using `roomToLoadPos map[string]int64` everywhere from now on. The current fix causes `UserRoomData` responses which have the correct timeline but incorrect (newer) other fields like `IsInvite`, `NotificationCount`, etc.