### PR TITLE
Remove timeline cache; fix flakey test

### DIFF
--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -45,7 +45,7 @@ type UserRoomData struct {
 	// Map of tag to order float.
 	// See https://spec.matrix.org/latest/client-server-api/#room-tagging
 	Tags map[string]float64
-	// the load state of the timeline
+	// LoadPos is an event NID. UserRoomData instances represent the status of this room after the corresponding event, as seen by this user.
 	LoadPos int64
 }
 

--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -473,7 +473,7 @@ func (s *ConnState) getInitialRoomData(ctx context.Context, roomSub sync3.RoomSu
 		var inviteState []json.RawMessage
 		// handle invites specially as we do not want to leak additional data beyond the invite_state and if
 		// we happen to have this room in the global cache we will do.
-		// Furthermore, rooms we have been invited to for the first time ever will not be in the global cache yet,
+		// Furthermore, rooms the proxy have been invited to for the first time ever will not be in the global cache yet,
 		// which will cause errors below when we try calling functions on a nil metadata.
 		if userRoomData.IsInvite {
 			metadata = userRoomData.Invite.RoomMetadata()

--- a/sync3/handler/connstate_test.go
+++ b/sync3/handler/connstate_test.go
@@ -49,7 +49,7 @@ func mockLazyRoomOverride(loadPos int64, roomIDs []string, maxTimelineEvents int
 	result := make(map[string]caches.UserRoomData)
 	for _, roomID := range roomIDs {
 		u := caches.NewUserRoomData()
-		u.Timeline = []json.RawMessage{[]byte(`{}`)}
+		u.RequestedTimeline = []json.RawMessage{[]byte(`{}`)}
 		result[roomID] = u
 	}
 	return result
@@ -99,7 +99,7 @@ func TestConnStateInitial(t *testing.T) {
 		result := make(map[string]caches.UserRoomData)
 		for _, roomID := range roomIDs {
 			u := caches.NewUserRoomData()
-			u.Timeline = []json.RawMessage{timeline[roomID]}
+			u.RequestedTimeline = []json.RawMessage{timeline[roomID]}
 			result[roomID] = u
 		}
 		return result
@@ -536,7 +536,7 @@ func TestConnStateRoomSubscriptions(t *testing.T) {
 		result := make(map[string]caches.UserRoomData)
 		for _, roomID := range roomIDs {
 			u := caches.NewUserRoomData()
-			u.Timeline = []json.RawMessage{timeline[roomID]}
+			u.RequestedTimeline = []json.RawMessage{timeline[roomID]}
 			result[roomID] = u
 		}
 		return result


### PR DESCRIPTION
- Fixes https://github.com/matrix-org/sliding-sync/issues/76 flakey test TestSecurityLiveStreamEventLeftLeak, caused by the test expecting 2 events to arrive in a single HTTP response.
- Remove the timeline cache in the user cache. This has been the source of numerous bugs around misordered and missing timeline events, and needs to be rewritten to take into account per-room load positions and handle trickling timeline limits better (starting with limit=0/1 then increasing to 20+).

