### PR TITLE
perf: improve startup speeds by using temp tables

### DIFF
--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -214,7 +214,11 @@ func TestStorageJoinedRoomsAfterPosition(t *testing.T) {
 			JoinCount: 2,
 		},
 	}
-	err = store.MetadataForAllRooms(txn, roomIDToMetadata)
+	tempTableName, err := store.PrepareSnapshot(txn)
+	if err != nil {
+		t.Fatalf("PrepareSnapshot: %s", err)
+	}
+	err = store.MetadataForAllRooms(txn, tempTableName, roomIDToMetadata)
 	txn.Commit()
 	if err != nil {
 		t.Fatalf("MetadataForAllRooms: %s", err)


### PR DESCRIPTION
When the proxy is run with large DBs (10m+ events), the startup queries are very slow (around 30min to load the initial snapshot.

After much EXPLAIN ANALYZEing, the cause is due to Postgres' query planner not making good decisions when the tables are that large. Specifically, the startup queries need to pull all joined members in all rooms, which ends up being nearly 50% of the entire events table of 10m rows. When this query is embedded in a subselect, the query planner assumes that the subselect will return only a few rows, and decides to pull those rows via an index. In this particular case, indexes are the wrong choice, as there are SO MANY rows a Seq Scan is often more appropriate. By using an index (which is a btree), this ends up doing log(n) operations _per row_ or `O(0.5 * n * log(n))` assuming we pull 50% of the table of n rows. As n increases, this is increasingly the wrong call over a basic O(n) seq scan. When n=10m, a seq scan has a cost of 10m, but using indexes has a cost of 16.6m. By dumping the result of the subselect to a temporary table, this allows the query planner to notice that using an index is the wrong thing to do, resulting in better performance. On large DBs, this decreases the startup time from 30m to ~5m.

On a backup database (which seems slower), this reduced startup queries from 1h35m to 6m24s, whilst keeping the end result byte for byte identical.
