### PR TITLE
feat: add rate limiting

### DIFF
--- a/tests-e2e/conns_test.go
+++ b/tests-e2e/conns_test.go
@@ -86,7 +86,7 @@ func TestMultipleConns(t *testing.T) {
 		},
 	}}, WithPos(resB.Pos))
 	m.MatchResponse(t, resB, m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
-		roomID: {MatchRoomRequiredState([]Event{{Type: "m.room.create", StateKey: ptr("")}})},
+		roomID: {MatchRoomRequiredStateStrict([]Event{{Type: "m.room.create", StateKey: ptr("")}})},
 	}))
 
 	// Conn C: create a list

--- a/tests-e2e/lazy_loading_test.go
+++ b/tests-e2e/lazy_loading_test.go
@@ -56,7 +56,7 @@ func TestLazyLoading(t *testing.T) {
 	})
 	m.MatchResponse(t, res, m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
 		roomID: {
-			MatchRoomRequiredState([]Event{
+			MatchRoomRequiredStateStrict([]Event{
 				{
 					Type:     "m.room.member",
 					StateKey: &charlie.UserID,
@@ -82,7 +82,7 @@ func TestLazyLoading(t *testing.T) {
 	})
 	m.MatchResponse(t, bobRes, m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
 		roomID: {
-			MatchRoomRequiredState([]Event{
+			MatchRoomRequiredStateStrict([]Event{
 				{
 					Type:     "m.room.member",
 					StateKey: &charlie.UserID,
@@ -113,7 +113,7 @@ func TestLazyLoading(t *testing.T) {
 	})
 	m.MatchResponse(t, charlieRes, m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
 		roomID: {
-			MatchRoomRequiredState([]Event{
+			MatchRoomRequiredStateStrict([]Event{
 				{
 					Type:     "m.room.member",
 					StateKey: &charlie.UserID,
@@ -153,7 +153,7 @@ func TestLazyLoading(t *testing.T) {
 				Type: "m.room.message",
 				ID:   aliceEventID,
 			}}),
-			MatchRoomRequiredState([]Event{{
+			MatchRoomRequiredStateStrict([]Event{{
 				Type:     "m.room.member",
 				StateKey: &alice.UserID,
 			}}),
@@ -172,7 +172,7 @@ func TestLazyLoading(t *testing.T) {
 				Type: "m.room.message",
 				ID:   aliceEventID2,
 			}}),
-			MatchRoomRequiredState(nil),
+			MatchRoomRequiredStateStrict(nil),
 		},
 	}))
 
@@ -190,7 +190,7 @@ func TestLazyLoading(t *testing.T) {
 					ID:   aliceEventID2,
 				},
 			}),
-			MatchRoomRequiredState([]Event{{
+			MatchRoomRequiredStateStrict([]Event{{
 				Type:     "m.room.member",
 				StateKey: &alice.UserID,
 			}}),

--- a/tests-e2e/lists_test.go
+++ b/tests-e2e/lists_test.go
@@ -415,7 +415,7 @@ func TestMultipleOverlappingLists(t *testing.T) {
 			// encrypted rooms just come from the encrypted only list
 			encryptedRoomIDs[0]: {
 				m.MatchRoomInitial(true),
-				MatchRoomRequiredState([]Event{
+				MatchRoomRequiredStateStrict([]Event{
 					{
 						Type:     "m.room.join_rules",
 						StateKey: ptr(""),
@@ -428,7 +428,7 @@ func TestMultipleOverlappingLists(t *testing.T) {
 			},
 			encryptedRoomIDs[1]: {
 				m.MatchRoomInitial(true),
-				MatchRoomRequiredState([]Event{
+				MatchRoomRequiredStateStrict([]Event{
 					{
 						Type:     "m.room.join_rules",
 						StateKey: ptr(""),
@@ -441,7 +441,7 @@ func TestMultipleOverlappingLists(t *testing.T) {
 			},
 			encryptedRoomIDs[2]: {
 				m.MatchRoomInitial(true),
-				MatchRoomRequiredState([]Event{
+				MatchRoomRequiredStateStrict([]Event{
 					{
 						Type:     "m.room.join_rules",
 						StateKey: ptr(""),
@@ -455,7 +455,7 @@ func TestMultipleOverlappingLists(t *testing.T) {
 			// overlapping with DM rooms
 			encryptedRoomIDs[3]: {
 				m.MatchRoomInitial(true),
-				MatchRoomRequiredState([]Event{
+				MatchRoomRequiredStateStrict([]Event{
 					{
 						Type:     "m.room.join_rules",
 						StateKey: ptr(""),
@@ -472,7 +472,7 @@ func TestMultipleOverlappingLists(t *testing.T) {
 			},
 			encryptedRoomIDs[4]: {
 				m.MatchRoomInitial(true),
-				MatchRoomRequiredState([]Event{
+				MatchRoomRequiredStateStrict([]Event{
 					{
 						Type:     "m.room.join_rules",
 						StateKey: ptr(""),
@@ -490,7 +490,7 @@ func TestMultipleOverlappingLists(t *testing.T) {
 			// DM only rooms
 			dmRoomIDs[2]: {
 				m.MatchRoomInitial(true),
-				MatchRoomRequiredState([]Event{
+				MatchRoomRequiredStateStrict([]Event{
 					{
 						Type:     "m.room.power_levels",
 						StateKey: ptr(""),
@@ -500,7 +500,7 @@ func TestMultipleOverlappingLists(t *testing.T) {
 			},
 			dmRoomIDs[3]: {
 				m.MatchRoomInitial(true),
-				MatchRoomRequiredState([]Event{
+				MatchRoomRequiredStateStrict([]Event{
 					{
 						Type:     "m.room.power_levels",
 						StateKey: ptr(""),
@@ -510,7 +510,7 @@ func TestMultipleOverlappingLists(t *testing.T) {
 			},
 			dmRoomIDs[4]: {
 				m.MatchRoomInitial(true),
-				MatchRoomRequiredState([]Event{
+				MatchRoomRequiredStateStrict([]Event{
 					{
 						Type:     "m.room.power_levels",
 						StateKey: ptr(""),

--- a/tests-e2e/main_test.go
+++ b/tests-e2e/main_test.go
@@ -118,9 +118,6 @@ func MatchRoomTimelineContains(event Event) m.RoomMatcher {
 
 func MatchRoomRequiredState(events []Event) m.RoomMatcher {
 	return func(r sync3.Room) error {
-		if len(r.RequiredState) != len(events) {
-			return fmt.Errorf("required state length mismatch, got %d want %d", len(r.RequiredState), len(events))
-		}
 		// allow any ordering for required state
 		for _, want := range events {
 			found := false
@@ -135,6 +132,15 @@ func MatchRoomRequiredState(events []Event) m.RoomMatcher {
 			}
 		}
 		return nil
+	}
+}
+
+func MatchRoomRequiredStateStrict(events []Event) m.RoomMatcher {
+	return func(r sync3.Room) error {
+		if len(r.RequiredState) != len(events) {
+			return fmt.Errorf("required state length mismatch, got %d want %d", len(r.RequiredState), len(events))
+		}
+		return MatchRoomRequiredState(events)(r)
 	}
 }
 

--- a/tests-e2e/membership_transitions_test.go
+++ b/tests-e2e/membership_transitions_test.go
@@ -87,7 +87,7 @@ func TestRoomStateTransitions(t *testing.T) {
 		},
 	}, WithPos(bobRes.Pos))
 	m.MatchResponse(t, bobRes, m.MatchNoV3Ops(), m.MatchList("a", m.MatchV3Count(2)), m.MatchRoomSubscription(inviteRoomID,
-		MatchRoomRequiredState([]Event{
+		MatchRoomRequiredStateStrict([]Event{
 			{
 				Type:     "m.room.create",
 				StateKey: ptr(""),

--- a/tests-e2e/tombstone_test.go
+++ b/tests-e2e/tombstone_test.go
@@ -66,7 +66,7 @@ func TestIncludeOldRooms(t *testing.T) {
 			m.MatchRoomInitial(true),
 			m.MatchJoinCount(1),
 			func(r sync3.Room) error { // nest it so the previous matcher has time to set tombstoneEventID
-				return MatchRoomRequiredState([]Event{
+				return MatchRoomRequiredStateStrict([]Event{
 					{
 						Type:     "m.room.create",
 						StateKey: ptr(""),
@@ -102,7 +102,7 @@ func TestIncludeOldRooms(t *testing.T) {
 		m.MatchV3SyncOp(0, 0, []string{newRoomID}),
 	)), m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
 		newRoomID: {
-			MatchRoomRequiredState([]Event{
+			MatchRoomRequiredStateStrict([]Event{
 				{
 					Type:     "m.room.member",
 					StateKey: &client.UserID,
@@ -110,7 +110,7 @@ func TestIncludeOldRooms(t *testing.T) {
 			}),
 		},
 		roomID: {
-			MatchRoomRequiredState([]Event{
+			MatchRoomRequiredStateStrict([]Event{
 				{
 					Type:     "m.room.create",
 					StateKey: ptr(""),
@@ -139,7 +139,7 @@ func TestIncludeOldRooms(t *testing.T) {
 		m.MatchV3SyncOp(0, 0, []string{newRoomID}),
 	)), m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
 		newRoomID: {
-			MatchRoomRequiredState([]Event{
+			MatchRoomRequiredStateStrict([]Event{
 				{
 					Type:     "m.room.member",
 					StateKey: &client.UserID,
@@ -203,7 +203,7 @@ func TestIncludeOldRoomsLongChain(t *testing.T) {
 	})
 	m.MatchResponse(t, res, m.MatchNoV3Ops(), m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
 		roomA: {
-			MatchRoomRequiredState([]Event{
+			MatchRoomRequiredStateStrict([]Event{
 				{
 					Type:     "m.room.create",
 					StateKey: ptr(""),
@@ -211,7 +211,7 @@ func TestIncludeOldRoomsLongChain(t *testing.T) {
 			}),
 		},
 		roomB: {
-			MatchRoomRequiredState([]Event{
+			MatchRoomRequiredStateStrict([]Event{
 				{
 					Type:     "m.room.member",
 					StateKey: &client.UserID,
@@ -245,7 +245,7 @@ func TestIncludeOldRoomsLongChain(t *testing.T) {
 	})
 	m.MatchResponse(t, res, m.MatchNoV3Ops(), m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
 		roomC: {
-			MatchRoomRequiredState([]Event{
+			MatchRoomRequiredStateStrict([]Event{
 				{
 					Type:     "m.room.create",
 					StateKey: ptr(""),
@@ -253,7 +253,7 @@ func TestIncludeOldRoomsLongChain(t *testing.T) {
 			}),
 		},
 		roomD: {
-			MatchRoomRequiredState([]Event{
+			MatchRoomRequiredStateStrict([]Event{
 				{
 					Type:     "m.room.member",
 					StateKey: &client.UserID,
@@ -297,7 +297,7 @@ func TestIncludeOldRoomsSubscriptionUnion(t *testing.T) {
 		m.MatchV3SyncOp(0, 0, []string{roomB}),
 	)), m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
 		roomA: {
-			MatchRoomRequiredState([]Event{
+			MatchRoomRequiredStateStrict([]Event{
 				{
 					Type: "m.room.create", StateKey: ptr(""),
 				},
@@ -316,7 +316,7 @@ func TestIncludeOldRoomsSubscriptionUnion(t *testing.T) {
 			},
 		},
 		roomB: {
-			MatchRoomRequiredState(nil),
+			MatchRoomRequiredStateStrict(nil),
 			MatchRoomTimeline(nil),
 		},
 	}))

--- a/tests-e2e/typing_test.go
+++ b/tests-e2e/typing_test.go
@@ -167,7 +167,6 @@ func TestTypingLazyLoad(t *testing.T) {
 				TimelineLimit: 1,
 				RequiredState: [][2]string{
 					{"m.room.member", "$LAZY"},
-					{"m.room.member", "$ME"},
 				},
 			},
 		},
@@ -303,7 +302,6 @@ func waitUntilTypingData(t *testing.T, client *CSAPI, roomID string, wantUserIDs
 				TimelineLimit: 1,
 				RequiredState: [][2]string{
 					{"m.room.member", "$LAZY"},
-					{"m.room.member", "$ME"},
 				},
 			},
 		},

--- a/tests-integration/v3_test.go
+++ b/tests-integration/v3_test.go
@@ -363,6 +363,9 @@ func runTestServer(t testutils.TestBenchInterface, v2Server *testV2Server, postg
 	if postgresConnectionString == "" {
 		postgresConnectionString = testutils.PrepareDBConnectionString()
 	}
+	//tests often repeat requests. To ensure tests remain fast, reduce the spam protection limits.
+	sync3.SpamProtectionInterval = time.Millisecond
+
 	metricsEnabled := false
 	maxPendingEventUpdates := 200
 	if len(opts) > 0 {


### PR DESCRIPTION
The server will wait 1s if clients:
 - repeat the same request (same `?pos=`)
 - repeatedly hit `/sync` without a `?pos=`.

Both of these failure modes have been seen in the wild. Fixes #93. Also fixes #55

