### PR TITLE
Per-list bump event types

### DIFF
--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -93,35 +93,35 @@ func (s *ConnState) load(ctx context.Context, req *sync3.Request) error {
 	for _, metadata := range joinedRooms {
 		metadata.RemoveHero(s.userID)
 		urd := s.userCache.LoadRoomData(metadata.RoomID)
-		timestamps := make(map[string]uint64, len(req.Lists))
+		interestedEventTimestampsByList := make(map[string]uint64, len(req.Lists))
 		for listKey, _ := range req.Lists {
 			// Best-effort only: we're not going to scan the database for all events in
 			// the entire room's history to give you a fully accurate timestamp
 			// according to your bump_event_types.
-			timestamps[listKey] = metadata.LastMessageTimestamp
+			interestedEventTimestampsByList[listKey] = metadata.LastMessageTimestamp
 		}
 		rooms[i] = sync3.RoomConnMetadata{
 			RoomMetadata:                  *metadata,
 			UserRoomData:                  urd,
-			LastInterestedEventTimestamps: timestamps,
+			LastInterestedEventTimestamps: interestedEventTimestampsByList,
 		}
 		i++
 	}
 	invites := s.userCache.Invites()
 	for _, urd := range invites {
 		metadata := urd.Invite.RoomMetadata()
-		timestamps := make(map[string]uint64, len(req.Lists))
+		inviteTimestampsByList := make(map[string]uint64, len(req.Lists))
 		for listKey, _ := range req.Lists {
 			// NB: If you've set bump_event_types to exclude membership events and
 			// there are no interesting messages after your invite event, when you join
 			// this timestamp is going to roll back to the last interesting event before
 			// your invite.
-			timestamps[listKey] = metadata.LastMessageTimestamp
+			inviteTimestampsByList[listKey] = metadata.LastMessageTimestamp
 		}
 		rooms = append(rooms, sync3.RoomConnMetadata{
 			RoomMetadata:                  *metadata,
 			UserRoomData:                  urd,
-			LastInterestedEventTimestamps: timestamps,
+			LastInterestedEventTimestamps: inviteTimestampsByList,
 		})
 	}
 

--- a/sync3/lists.go
+++ b/sync3/lists.go
@@ -150,16 +150,20 @@ func (s *InternalRequestLists) RemoveRoom(roomID string) {
 }
 
 func (s *InternalRequestLists) DeleteList(listKey string) {
-	// TODO
-	// TODO: could remove listKey's LastInterestedMessageTimestamp entries in allRooms
+	delete(s.lists, listKey)
+	for _, room := range s.allRooms {
+		delete(room.LastInterestedEventTimestamps, listKey)
+	}
 }
 
-// Returns the underlying Room object. Returns a shared pointer, not a copy.
+// Returns the underlying RoomConnMetadata object. Returns a shared pointer, not a copy.
 // It is only safe to read this data, never to write.
 func (s *InternalRequestLists) ReadOnlyRoom(roomID string) *RoomConnMetadata {
 	return s.allRooms[roomID]
 }
 
+// Get returns the sorted list of rooms. Returns a shared pointer, not a copy.
+// It is only safe to read this data, never to write.
 func (s *InternalRequestLists) Get(listKey string) *FilteredSortableRooms {
 	return s.lists[listKey]
 }

--- a/sync3/lists.go
+++ b/sync3/lists.go
@@ -194,7 +194,7 @@ func (s *InternalRequestLists) AssignList(ctx context.Context, listKey string, f
 		i++
 	}
 
-	roomList := NewFilteredSortableRooms(s, roomIDs, filters)
+	roomList := NewFilteredSortableRooms(s, listKey, roomIDs, filters)
 	if sort != nil {
 		err := roomList.Sort(sort)
 		if err != nil {

--- a/sync3/lists.go
+++ b/sync3/lists.go
@@ -76,10 +76,10 @@ func (s *InternalRequestLists) SetRoom(r RoomConnMetadata) (delta RoomDelta) {
 
 		// Interpret the timestamp map on r as the changes we should apply atop the
 		// existing timestamps.
-		bumpListsTo := r.LastInterestedEventTimestamps
+		newTimestamps := r.LastInterestedEventTimestamps
 		r.LastInterestedEventTimestamps = make(map[string]uint64, len(s.lists))
 		for listKey := range s.lists {
-			newTs, bump := bumpListsTo[listKey]
+			newTs, bump := newTimestamps[listKey]
 			if bump {
 				r.LastInterestedEventTimestamps[listKey] = newTs
 			} else {

--- a/sync3/lists.go
+++ b/sync3/lists.go
@@ -156,6 +156,18 @@ func (s *InternalRequestLists) Get(listKey string) *FilteredSortableRooms {
 	return s.lists[listKey]
 }
 
+// ListKeys returns a copy of the list keys currently tracked by this
+// InternalRequestLists struct, in no particular order. Outside of test code, you
+// probably don't want to call this---you probably have the set of list keys tracked
+// elsewhere in the application.
+func (s *InternalRequestLists) ListKeys() []string {
+	keys := make([]string, len(s.lists))
+	for listKey, _ := range s.lists {
+		keys = append(keys, listKey)
+	}
+	return keys
+}
+
 // ListsByVisibleRoomIDs builds a map from room IDs to a slice of list names. Keys are
 // all room IDs that are currently visible in at least one sliding window. Values are
 // the names of all lists (in no particular order) in which the given room ID is

--- a/sync3/lists_test.go
+++ b/sync3/lists_test.go
@@ -41,7 +41,7 @@ func addRooms(list *sync3.InternalRequestLists, n int) {
 			UserRoomData: caches.UserRoomData{
 				IsDM: next%10 == 0,
 			},
-			LastInterestedEventTimestamp: messageTimestamp,
-		}, true)
+			LastInterestedEventTimestamps: make(map[string]uint64),
+		})
 	}
 }

--- a/sync3/lists_test.go
+++ b/sync3/lists_test.go
@@ -31,6 +31,10 @@ func addRooms(list *sync3.InternalRequestLists, n int) {
 	for i := 0; i < n; i++ {
 		next := roomCounter.Add(1)
 		messageTimestamp := uint64(timestamp.Add(time.Duration(next) * time.Minute).UnixMilli())
+		lastInterestedEventTimestamps := make(map[string]uint64)
+		for _, listKey := range list.ListKeys() {
+			lastInterestedEventTimestamps[listKey] = messageTimestamp
+		}
 		list.SetRoom(sync3.RoomConnMetadata{
 			RoomMetadata: internal.RoomMetadata{
 				RoomID:               fmt.Sprintf("!%d:benchmark", next),
@@ -41,7 +45,7 @@ func addRooms(list *sync3.InternalRequestLists, n int) {
 			UserRoomData: caches.UserRoomData{
 				IsDM: next%10 == 0,
 			},
-			LastInterestedEventTimestamps: make(map[string]uint64),
+			LastInterestedEventTimestamps: lastInterestedEventTimestamps,
 		})
 	}
 }

--- a/sync3/room.go
+++ b/sync3/room.go
@@ -52,16 +52,17 @@ type RoomConnMetadata struct {
 
 func (r *RoomConnMetadata) GetLastInterestedEventTimestamp(listKey string) uint64 {
 	ts, ok := r.LastInterestedEventTimestamps[listKey]
-	if !ok {
-		// SetRoom is responsible for maintaining LastInterestedEventTimestamps.
-		// However, if a brand-new list appears and we don't call SetRoom, we need to
-		// ensure we hand back a sensible timestamp. So: use the (current)
-		// LastMessageTimestamp as a fallback.
-		ts = r.LastMessageTimestamp
-		// Write this value into the map. If we don't and only uninteresting events
-		// arrive after, the fallback value will have jumped ahead despite nothing of
-		// interest happening.
-		r.LastInterestedEventTimestamps[listKey] = ts
+	if ok {
+		return ts
 	}
+	// SetRoom is responsible for maintaining LastInterestedEventTimestamps.
+	// However, if a brand-new list appears and we don't call SetRoom, we need to
+	// ensure we hand back a sensible timestamp. So: use the (current)
+	// LastMessageTimestamp as a fallback.
+	ts = r.LastMessageTimestamp
+	// Write this value into the map. If we don't and only uninteresting events
+	// arrive after, the fallback value will have jumped ahead despite nothing of
+	// interest happening.
+	r.LastInterestedEventTimestamps[listKey] = ts
 	return ts
 }

--- a/sync3/room.go
+++ b/sync3/room.go
@@ -33,10 +33,13 @@ type RoomConnMetadata struct {
 	caches.UserRoomData
 	// plus any per-conn data.
 
-	// LastInterestedEventTimestamp is the origin_server_ts of the most recent event
-	// seen in the room that this connection is interested in. Connections can specify
-	// that they are only in certain event types by providing "bump_event_types" in
-	// their sliding sync request.
+	// LastInterestedEventTimestamps is a map from list names to the origin_server_ts of
+	// the most recent event seen in the room that the list is interested in.
+	// Connections can specify that a list is only interested in certain event types by
+	// providing "bump_event_types" in their sliding sync request. This happens on a
+	// list-by-list basis. Because the same room can appear in different lists with
+	// different bump criteria, we need to track a LastInterestedEventTimestamp for each
+	// list.
 	//
 	// While this conceptually tracks the internal.RoomMetadata.LastMessageTimestamp
 	// field, said field can decrease rapidly at any moment---so
@@ -44,5 +47,5 @@ type RoomConnMetadata struct {
 	// recency, this means rooms can suddenly fall down and jump back up the room
 	// list. See also the description of this in the React SDK docs:
 	//     https://github.com/matrix-org/matrix-react-sdk/blob/526645c79160ab1ad4b4c3845de27d51263a405e/docs/room-list-store.md#tag-sorting-algorithm-recent
-	LastInterestedEventTimestamp uint64
+	LastInterestedEventTimestamps map[string]uint64
 }

--- a/sync3/room.go
+++ b/sync3/room.go
@@ -49,3 +49,19 @@ type RoomConnMetadata struct {
 	//     https://github.com/matrix-org/matrix-react-sdk/blob/526645c79160ab1ad4b4c3845de27d51263a405e/docs/room-list-store.md#tag-sorting-algorithm-recent
 	LastInterestedEventTimestamps map[string]uint64
 }
+
+func (r *RoomConnMetadata) GetLastInterestedEventTimestamp(listKey string) uint64 {
+	ts, ok := r.LastInterestedEventTimestamps[listKey]
+	if !ok {
+		// SetRoom is responsible for maintaining LastInterestedEventTimestamps.
+		// However, if a brand-new list appears and we don't call SetRoom, we need to
+		// ensure we hand back a sensible timestamp. So: use the (current)
+		// LastMessageTimestamp as a fallback.
+		ts = r.LastMessageTimestamp
+		// Write this value into the map. If we don't and only uninteresting events
+		// arrive after, the fallback value will have jumped ahead despite nothing of
+		// interest happening.
+		r.LastInterestedEventTimestamps[listKey] = ts
+	}
+	return ts
+}

--- a/sync3/sort.go
+++ b/sync3/sort.go
@@ -147,10 +147,12 @@ func (s *SortableRooms) comparatorSortByName(i, j int) int {
 
 func (s *SortableRooms) comparatorSortByRecency(i, j int) int {
 	ri, rj := s.resolveRooms(i, j)
-	if ri.GetLastInterestedEventTimestamp(s.listKey) == rj.GetLastInterestedEventTimestamp(s.listKey) {
+	tsRi := ri.GetLastInterestedEventTimestamp(s.listKey)
+	tsRj := rj.GetLastInterestedEventTimestamp(s.listKey)
+	if tsRi == tsRj {
 		return 0
 	}
-	if ri.GetLastInterestedEventTimestamp(s.listKey) > rj.GetLastInterestedEventTimestamp(s.listKey) {
+	if tsRi > tsRj {
 		return 1
 	}
 	return -1

--- a/sync3/sort.go
+++ b/sync3/sort.go
@@ -147,10 +147,10 @@ func (s *SortableRooms) comparatorSortByName(i, j int) int {
 
 func (s *SortableRooms) comparatorSortByRecency(i, j int) int {
 	ri, rj := s.resolveRooms(i, j)
-	if ri.LastInterestedEventTimestamps[s.listKey] == rj.LastInterestedEventTimestamps[s.listKey] {
+	if ri.GetLastInterestedEventTimestamp(s.listKey) == rj.GetLastInterestedEventTimestamp(s.listKey) {
 		return 0
 	}
-	if ri.LastInterestedEventTimestamps[s.listKey] > rj.LastInterestedEventTimestamps[s.listKey] {
+	if ri.GetLastInterestedEventTimestamp(s.listKey) > rj.GetLastInterestedEventTimestamp(s.listKey) {
 		return 1
 	}
 	return -1

--- a/sync3/sort.go
+++ b/sync3/sort.go
@@ -147,10 +147,10 @@ func (s *SortableRooms) comparatorSortByName(i, j int) int {
 
 func (s *SortableRooms) comparatorSortByRecency(i, j int) int {
 	ri, rj := s.resolveRooms(i, j)
-	if ri.LastInterestedEventTimestamp == rj.LastInterestedEventTimestamp {
+	if ri.LastInterestedEventTimestamps[s.listKey] == rj.LastInterestedEventTimestamps[s.listKey] {
 		return 0
 	}
-	if ri.LastInterestedEventTimestamp > rj.LastInterestedEventTimestamp {
+	if ri.LastInterestedEventTimestamps[s.listKey] > rj.LastInterestedEventTimestamps[s.listKey] {
 		return 1
 	}
 	return -1

--- a/sync3/sort.go
+++ b/sync3/sort.go
@@ -15,14 +15,16 @@ type RoomFinder interface {
 // room IDs to current index positions after sorting.
 type SortableRooms struct {
 	finder        RoomFinder
+	listKey       string
 	roomIDs       []string
 	roomIDToIndex map[string]int // room_id -> index in rooms
 }
 
-func NewSortableRooms(finder RoomFinder, rooms []string) *SortableRooms {
+func NewSortableRooms(finder RoomFinder, listKey string, rooms []string) *SortableRooms {
 	return &SortableRooms{
 		roomIDs:       rooms,
 		finder:        finder,
+		listKey:       listKey,
 		roomIDToIndex: make(map[string]int),
 	}
 }
@@ -216,7 +218,7 @@ type FilteredSortableRooms struct {
 	filter *RequestFilters
 }
 
-func NewFilteredSortableRooms(finder RoomFinder, roomIDs []string, filter *RequestFilters) *FilteredSortableRooms {
+func NewFilteredSortableRooms(finder RoomFinder, listKey string, roomIDs []string, filter *RequestFilters) *FilteredSortableRooms {
 	var filteredRooms []string
 	if filter == nil {
 		filter = &RequestFilters{}
@@ -228,7 +230,7 @@ func NewFilteredSortableRooms(finder RoomFinder, roomIDs []string, filter *Reque
 		}
 	}
 	return &FilteredSortableRooms{
-		SortableRooms: NewSortableRooms(finder, filteredRooms),
+		SortableRooms: NewSortableRooms(finder, listKey, filteredRooms),
 		filter:        filter,
 	}
 }

--- a/sync3/sort_test.go
+++ b/sync3/sort_test.go
@@ -32,6 +32,7 @@ func newFinder(rooms []*RoomConnMetadata) finder {
 }
 
 func TestSortBySingleOperation(t *testing.T) {
+	const listKey = "my_list"
 	room1 := "!1:localhost"
 	room2 := "!2:localhost"
 	room3 := "!3:localhost"
@@ -46,7 +47,7 @@ func TestSortBySingleOperation(t *testing.T) {
 				NotificationCount: 12,
 				CanonicalisedName: "foo",
 			},
-			LastInterestedEventTimestamp: 600,
+			LastInterestedEventTimestamps: map[string]uint64{listKey: 600},
 		},
 		{
 			RoomMetadata: internal.RoomMetadata{
@@ -57,7 +58,7 @@ func TestSortBySingleOperation(t *testing.T) {
 				NotificationCount: 3,
 				CanonicalisedName: "koo",
 			},
-			LastInterestedEventTimestamp: 700,
+			LastInterestedEventTimestamps: map[string]uint64{listKey: 700},
 		},
 		{
 			RoomMetadata: internal.RoomMetadata{
@@ -68,7 +69,7 @@ func TestSortBySingleOperation(t *testing.T) {
 				NotificationCount: 7,
 				CanonicalisedName: "yoo",
 			},
-			LastInterestedEventTimestamp: 900,
+			LastInterestedEventTimestamps: map[string]uint64{listKey: 900},
 		},
 		{
 			RoomMetadata: internal.RoomMetadata{
@@ -79,7 +80,7 @@ func TestSortBySingleOperation(t *testing.T) {
 				NotificationCount: 1,
 				CanonicalisedName: "boo",
 			},
-			LastInterestedEventTimestamp: 800,
+			LastInterestedEventTimestamps: map[string]uint64{listKey: 800},
 		},
 	}
 	// name: 4,1,2,3
@@ -95,7 +96,7 @@ func TestSortBySingleOperation(t *testing.T) {
 		SortByNotificationLevel + " " + SortByRecency: {room3, room4, room1, room2},
 	}
 	f := newFinder(rooms)
-	sr := NewSortableRooms(f, f.roomIDs)
+	sr := NewSortableRooms(f, listKey, f.roomIDs)
 	for sortBy, wantOrder := range wantMap {
 		sr.Sort(strings.Split(sortBy, " "))
 		var gotRoomIDs []string
@@ -111,6 +112,7 @@ func TestSortBySingleOperation(t *testing.T) {
 }
 
 func TestSortByMultipleOperations(t *testing.T) {
+	const listKey = "my_list"
 	room1 := "!1:localhost"
 	room2 := "!2:localhost"
 	room3 := "!3:localhost"
@@ -125,7 +127,7 @@ func TestSortByMultipleOperations(t *testing.T) {
 				NotificationCount: 1,
 				CanonicalisedName: "foo",
 			},
-			LastInterestedEventTimestamp: 600,
+			LastInterestedEventTimestamps: map[string]uint64{listKey: 600},
 		},
 		{
 			RoomMetadata: internal.RoomMetadata{
@@ -136,7 +138,7 @@ func TestSortByMultipleOperations(t *testing.T) {
 				NotificationCount: 5,
 				CanonicalisedName: "koo",
 			},
-			LastInterestedEventTimestamp: 700,
+			LastInterestedEventTimestamps: map[string]uint64{listKey: 700},
 		},
 		{
 			RoomMetadata: internal.RoomMetadata{
@@ -147,7 +149,7 @@ func TestSortByMultipleOperations(t *testing.T) {
 				NotificationCount: 0,
 				CanonicalisedName: "yoo",
 			},
-			LastInterestedEventTimestamp: 800,
+			LastInterestedEventTimestamps: map[string]uint64{listKey: 800},
 		},
 		{
 			RoomMetadata: internal.RoomMetadata{
@@ -158,7 +160,7 @@ func TestSortByMultipleOperations(t *testing.T) {
 				NotificationCount: 0,
 				CanonicalisedName: "boo",
 			},
-			LastInterestedEventTimestamp: 900,
+			LastInterestedEventTimestamps: map[string]uint64{listKey: 900},
 		},
 	}
 	testCases := []struct {
@@ -183,7 +185,7 @@ func TestSortByMultipleOperations(t *testing.T) {
 		},
 	}
 	f := newFinder(rooms)
-	sr := NewSortableRooms(f, f.roomIDs)
+	sr := NewSortableRooms(f, listKey, f.roomIDs)
 	for _, tc := range testCases {
 		sr.Sort(tc.SortBy)
 		var gotRoomIDs []string
@@ -200,6 +202,7 @@ func TestSortByMultipleOperations(t *testing.T) {
 
 // Test that if you remove a room, it updates the lookup map.
 func TestSortableRoomsRemove(t *testing.T) {
+	const listKey = "my_list"
 	room1 := "!1:localhost"
 	room2 := "!2:localhost"
 	rooms := []*RoomConnMetadata{
@@ -212,7 +215,7 @@ func TestSortableRoomsRemove(t *testing.T) {
 				NotificationCount: 1,
 				CanonicalisedName: "foo",
 			},
-			LastInterestedEventTimestamp: 700,
+			LastInterestedEventTimestamps: map[string]uint64{listKey: 700},
 		},
 		{
 			RoomMetadata: internal.RoomMetadata{
@@ -223,11 +226,11 @@ func TestSortableRoomsRemove(t *testing.T) {
 				NotificationCount: 2,
 				CanonicalisedName: "foo2",
 			},
-			LastInterestedEventTimestamp: 600,
+			LastInterestedEventTimestamps: map[string]uint64{listKey: 600},
 		},
 	}
 	f := newFinder(rooms)
-	sr := NewSortableRooms(f, f.roomIDs)
+	sr := NewSortableRooms(f, listKey, f.roomIDs)
 	if err := sr.Sort([]string{SortByRecency}); err != nil { // room 1 is first, then room 2
 		t.Fatalf("Sort: %s", err)
 	}
@@ -253,6 +256,7 @@ func TestSortableRoomsRemove(t *testing.T) {
 
 // dedicated test as it relies on multiple fields
 func TestSortByNotificationLevel(t *testing.T) {
+	const listKey = "my_list"
 	// create the full set of possible sort variables, most recent message last
 	roomUnencHC := "!unencrypted-highlight-count:localhost"
 	roomUnencHCNC := "!unencrypted-highlight-and-notif-count:localhost"
@@ -271,7 +275,7 @@ func TestSortByNotificationLevel(t *testing.T) {
 				HighlightCount:    1,
 				NotificationCount: 0,
 			},
-			LastInterestedEventTimestamp: 1,
+			LastInterestedEventTimestamps: map[string]uint64{listKey: 1},
 		},
 		roomUnencHCNC: {
 			RoomMetadata: internal.RoomMetadata{
@@ -281,7 +285,7 @@ func TestSortByNotificationLevel(t *testing.T) {
 				HighlightCount:    1,
 				NotificationCount: 1,
 			},
-			LastInterestedEventTimestamp: 2,
+			LastInterestedEventTimestamps: map[string]uint64{listKey: 2},
 		},
 		roomUnencNC: {
 			RoomMetadata: internal.RoomMetadata{
@@ -291,7 +295,7 @@ func TestSortByNotificationLevel(t *testing.T) {
 				HighlightCount:    0,
 				NotificationCount: 1,
 			},
-			LastInterestedEventTimestamp: 3,
+			LastInterestedEventTimestamps: map[string]uint64{listKey: 3},
 		},
 		roomUnenc: {
 			RoomMetadata: internal.RoomMetadata{
@@ -301,7 +305,7 @@ func TestSortByNotificationLevel(t *testing.T) {
 				HighlightCount:    0,
 				NotificationCount: 0,
 			},
-			LastInterestedEventTimestamp: 4,
+			LastInterestedEventTimestamps: map[string]uint64{listKey: 4},
 		},
 		roomEncHC: {
 			RoomMetadata: internal.RoomMetadata{
@@ -311,7 +315,7 @@ func TestSortByNotificationLevel(t *testing.T) {
 				HighlightCount:    1,
 				NotificationCount: 0,
 			},
-			LastInterestedEventTimestamp: 5,
+			LastInterestedEventTimestamps: map[string]uint64{listKey: 5},
 		},
 		roomEncHCNC: {
 			RoomMetadata: internal.RoomMetadata{
@@ -321,7 +325,7 @@ func TestSortByNotificationLevel(t *testing.T) {
 				HighlightCount:    1,
 				NotificationCount: 1,
 			},
-			LastInterestedEventTimestamp: 6,
+			LastInterestedEventTimestamps: map[string]uint64{listKey: 6},
 		},
 		roomEncNC: {
 			RoomMetadata: internal.RoomMetadata{
@@ -332,7 +336,7 @@ func TestSortByNotificationLevel(t *testing.T) {
 				HighlightCount:    0,
 				NotificationCount: 1,
 			},
-			LastInterestedEventTimestamp: 7,
+			LastInterestedEventTimestamps: map[string]uint64{listKey: 7},
 		},
 		roomEnc: {
 			RoomMetadata: internal.RoomMetadata{
@@ -343,7 +347,7 @@ func TestSortByNotificationLevel(t *testing.T) {
 				HighlightCount:    0,
 				NotificationCount: 0,
 			},
-			LastInterestedEventTimestamp: 8,
+			LastInterestedEventTimestamps: map[string]uint64{listKey: 8},
 		},
 	}
 	roomIDs := make([]string, len(roomsMap))
@@ -357,7 +361,7 @@ func TestSortByNotificationLevel(t *testing.T) {
 	}
 	t.Logf("%v", roomIDs)
 	f := newFinder(rooms)
-	sr := NewSortableRooms(f, roomIDs)
+	sr := NewSortableRooms(f, listKey, roomIDs)
 	if err := sr.Sort([]string{SortByNotificationLevel, SortByRecency}); err != nil {
 		t.Fatalf("Sort: %s", err)
 	}

--- a/tests-e2e/lists_test.go
+++ b/tests-e2e/lists_test.go
@@ -907,12 +907,12 @@ func TestBumpEventTypesHandling(t *testing.T) {
 			RequiredState: [][2]string{{"m.room.avatar", ""}, {"m.room.encryption", ""}},
 			TimelineLimit: 10,
 		},
+		BumpEventTypes: []string{"m.room.message", "m.room.encrypted"},
 	}
 	aliceSyncRequest := sync3.Request{
 		Lists: map[string]sync3.RequestList{
 			"alice_list": aliceReqList,
 		},
-		BumpEventTypes: []string{"m.room.message", "m.room.encrypted"},
 	}
 	// This sync should include both of Bob's messages. The proxy will make an initial
 	// V2 sync to the HS, which should include the latest event in both rooms.
@@ -936,12 +936,12 @@ func TestBumpEventTypesHandling(t *testing.T) {
 			RequiredState: [][2]string{{"m.room.avatar", ""}, {"m.room.encryption", ""}},
 			TimelineLimit: 10,
 		},
+		BumpEventTypes: []string{"m.room.message", "m.room.encrypted", "m.room.member"},
 	}
 	bobSyncRequest := sync3.Request{
 		Lists: map[string]sync3.RequestList{
 			"bob_list": bobReqList,
 		},
-		BumpEventTypes: []string{"m.room.message", "m.room.encrypted", "m.room.member"},
 	}
 	bobRes := bob.SlidingSync(t, bobSyncRequest)
 

--- a/tests-e2e/main_test.go
+++ b/tests-e2e/main_test.go
@@ -167,14 +167,18 @@ func MatchRoomInviteState(events []Event, partial bool) m.RoomMatcher {
 }
 
 func registerNewUser(t *testing.T) *CSAPI {
+	return registerNamedUser(t, "user")
+}
+
+func registerNamedUser(t *testing.T, localpartPrefix string) *CSAPI {
 	// create user
+	localpart := fmt.Sprintf("%s-%d-%d", localpartPrefix, time.Now().Unix(), atomic.AddUint64(&userCounter, 1))
 	httpClient := NewLoggedClient(t, "localhost", nil)
 	client := &CSAPI{
 		Client:           httpClient,
 		BaseURL:          homeserverBaseURL,
 		SyncUntilTimeout: 3 * time.Second,
 	}
-	localpart := fmt.Sprintf("user-%d-%d", time.Now().Unix(), atomic.AddUint64(&userCounter, 1))
 
 	client.UserID, client.AccessToken, client.DeviceID = client.RegisterUser(t, localpart, "password")
 	client.Localpart = strings.Split(client.UserID, ":")[0][1:]


### PR DESCRIPTION
Good enough for a first review pass.

Closes #78.

I still want to:
- [x] cleanup timestamp entries when a list gets deleted from the sync request
- [x] write an E2E test which demonstrates that the same room can be bumped independently in different lists