### PR TITLE
Alter the method to check whether a client request includes a body

### DIFF
--- a/sync3/handler/handler.go
+++ b/sync3/handler/handler.go
@@ -183,7 +183,7 @@ func (h *SyncLiveHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 // Entry point for sync v3
 func (h *SyncLiveHandler) serve(w http.ResponseWriter, req *http.Request) error {
 	var requestBody sync3.Request
-	if req.Body != nil {
+	if req.ContentLength != 0 {
 		defer req.Body.Close()
 		if err := json.NewDecoder(req.Body).Decode(&requestBody); err != nil {
 			log.Err(err).Msg("failed to read/decode request body")


### PR DESCRIPTION
According to `net.http.Request.Body`'s documentation, when handling requests server-side, `req.Body` is never `nil`: https://pkg.go.dev/net/http#Request

I ran into an issue where Element was checking whether the sliding-sync endpoint existed by hitting the endpoint with no body, and that returned a 500 error (it assumed the homeserver didn't support sliding sync!).

So we replace this check with a different one, which works in my testing.