### PR TITLE
Various sentry cleanups

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -26,6 +26,10 @@ func (e *HandlerError) Error() string {
 	return fmt.Sprintf("HTTP %d : %s", e.StatusCode, e.Err.Error())
 }
 
+func (e *HandlerError) Unwrap() error {
+	return e.Err
+}
+
 type jsonError struct {
 	Err  string `json:"error"`
 	Code string `json:"errcode,omitempty"`

--- a/sync3/conn.go
+++ b/sync3/conn.go
@@ -98,8 +98,6 @@ func (c *Conn) tryRequest(ctx context.Context, req *Request) (res *Response, err
 			// I'm guessing that Sentry will use the former to display panicErr as
 			// having come from a panic.
 			internal.GetSentryHubFromContextOrDefault(ctx).RecoverWithContext(ctx, panicErr)
-		} else if err != nil {
-			internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(err)
 		}
 	}()
 	taskType := "OnIncomingRequest"

--- a/sync3/conn.go
+++ b/sync3/conn.go
@@ -80,8 +80,17 @@ func (c *Conn) OnUpdate(ctx context.Context, update caches.Update) {
 	c.handler.OnUpdate(ctx, update)
 }
 
+// tryRequest is a wrapper around ConnHandler.OnIncomingRequest which automatically
+// starts and closes a tracing task.
+//
+// If the wrapped call panics, it is recovered from, reported to Sentry, and an error
+// is passed to the caller. If the wrapped call returns an error, that error is passed
+// upwards but will NOT be logged to Sentry (neither here nor by the caller). Errors
+// should be reported to Sentry as close as possible to the point of creating the error,
+// to provide the best possible Sentry traceback.
 func (c *Conn) tryRequest(ctx context.Context, req *Request) (res *Response, err error) {
 	// TODO: include useful information from the request in the sentry hub/context
+	// Might be better done in the caller though?
 	defer func() {
 		panicErr := recover()
 		if panicErr != nil {
@@ -119,7 +128,10 @@ func (c *Conn) isOutstanding(pos int64) bool {
 	return false
 }
 
-// OnIncomingRequest advances the clients position in the stream, returning the response position and data.
+// OnIncomingRequest advances the client's position in the stream, returning the response position and data.
+// If an error is returned, it will be logged by the caller and transmitted to the
+// client. It will NOT be reported to Sentry---this should happen as close as possible
+// to the creation of the error (or else Sentry cannot provide a meaningful traceback.)
 func (c *Conn) OnIncomingRequest(ctx context.Context, req *Request) (resp *Response, herr *internal.HandlerError) {
 	c.cancelOutstandingRequestMu.Lock()
 	if c.cancelOutstandingRequest != nil {

--- a/sync3/extensions/extensions.go
+++ b/sync3/extensions/extensions.go
@@ -257,7 +257,7 @@ type Context struct {
 
 type HandlerInterface interface {
 	Handle(ctx context.Context, req Request, extCtx Context) (res Response)
-	HandleLiveUpdate(update caches.Update, req Request, res *Response, extCtx Context)
+	HandleLiveUpdate(ctx context.Context, update caches.Update, req Request, res *Response, extCtx Context)
 }
 
 type Handler struct {
@@ -266,11 +266,11 @@ type Handler struct {
 	GlobalCache *caches.GlobalCache
 }
 
-func (h *Handler) HandleLiveUpdate(update caches.Update, req Request, res *Response, extCtx Context) {
+func (h *Handler) HandleLiveUpdate(ctx context.Context, update caches.Update, req Request, res *Response, extCtx Context) {
 	extCtx.Handler = h
 	exts := req.EnabledExtensions()
 	for _, ext := range exts {
-		ext.AppendLive(context.Background(), res, extCtx, update)
+		ext.AppendLive(ctx, res, extCtx, update)
 	}
 }
 

--- a/sync3/extensions/todevice.go
+++ b/sync3/extensions/todevice.go
@@ -86,12 +86,9 @@ func (r *ToDeviceRequest) ProcessInitial(ctx context.Context, res *Response, ext
 	mapMu.Unlock()
 	if from < lastSentPos {
 		// we told the client about a newer position, but yet they are using an older position, yell loudly
-		const errMsg = "Client did not increment since token: possibly sending back duplicate to-device events!"
 		l.Warn().Int64("last_sent", lastSentPos).Int64("recv", from).Bool("initial", extCtx.IsInitial).Msg(
-			errMsg,
+			"Client did not increment since token: possibly sending back duplicate to-device events!",
 		)
-		// TODO add context to sentry
-		internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(fmt.Errorf(errMsg))
 	}
 
 	msgs, upTo, err := extCtx.Store.ToDeviceTable.Messages(extCtx.UserID, extCtx.DeviceID, from, int64(r.Limit))

--- a/sync3/handler/connstate_live.go
+++ b/sync3/handler/connstate_live.go
@@ -88,7 +88,7 @@ func (s *connStateLive) liveUpdate(
 			s.processLiveUpdate(ctx, update, response)
 			// pass event to extensions AFTER processing
 			roomIDsToLists := s.lists.ListsByVisibleRoomIDs(s.muxedReq.Lists)
-			s.extensionsHandler.HandleLiveUpdate(update, ex, &response.Extensions, extensions.Context{
+			s.extensionsHandler.HandleLiveUpdate(ctx, update, ex, &response.Extensions, extensions.Context{
 				IsInitial:        false,
 				RoomIDToTimeline: response.RoomIDsToTimelineEventIDs(),
 				UserID:           s.userID,
@@ -99,7 +99,7 @@ func (s *connStateLive) liveUpdate(
 			for len(s.updates) > 0 && response.ListOps() < 50 {
 				update = <-s.updates
 				s.processLiveUpdate(ctx, update, response)
-				s.extensionsHandler.HandleLiveUpdate(update, ex, &response.Extensions, extensions.Context{
+				s.extensionsHandler.HandleLiveUpdate(ctx, update, ex, &response.Extensions, extensions.Context{
 					IsInitial:        false,
 					RoomIDToTimeline: response.RoomIDsToTimelineEventIDs(),
 					UserID:           s.userID,

--- a/sync3/handler/connstate_test.go
+++ b/sync3/handler/connstate_test.go
@@ -22,7 +22,7 @@ func (h *NopExtensionHandler) Handle(ctx context.Context, req extensions.Request
 	return
 }
 
-func (h *NopExtensionHandler) HandleLiveUpdate(u caches.Update, req extensions.Request, res *extensions.Response, extCtx extensions.Context) {
+func (h *NopExtensionHandler) HandleLiveUpdate(ctx context.Context, update caches.Update, req extensions.Request, res *extensions.Response, extCtx extensions.Context) {
 }
 
 type NopJoinTracker struct{}


### PR DESCRIPTION
This (hypothetically, untested) improves a bit chunk of noisy errors seen in the `sync3` part of the source. Commitwise reviewable.