### PR TITLE
WIP: Support for msc3946

### DIFF
--- a/pubsub/v2.go
+++ b/pubsub/v2.go
@@ -36,6 +36,10 @@ type V2Accumulate struct {
 	RoomID    string
 	PrevBatch string
 	EventNIDs []int64
+	// RoomReplacements is a slice of string pairs (old, new). Each entry corresponds
+	// to a state event that the poller has just seen in the new room which marks the
+	// new room as replacing the old room.
+	RoomReplacements [][2]string
 }
 
 func (*V2Accumulate) Type() string { return "V2Accumulate" }

--- a/state/accumulator.go
+++ b/state/accumulator.go
@@ -105,9 +105,16 @@ func (a *Accumulator) roomInfoDelta(roomID string, events []Event) RoomInfo {
 			isEncrypted = true
 		}
 		if ev.Type == "m.room.tombstone" && ev.StateKey == "" {
-			contentType := gjson.GetBytes(ev.JSON, "content.replacement_room")
-			if contentType.Exists() && contentType.Type == gjson.String {
-				upgradedRoomID = &contentType.Str
+			replacementRoomID := gjson.GetBytes(ev.JSON, "content.replacement_room")
+			if replacementRoomID.Exists() && replacementRoomID.Type == gjson.String {
+				upgradedRoomID = &replacementRoomID.Str
+			}
+		}
+		// TODO: use stable identifier if MSC is accepted
+		if ev.Type == "org.matrix.msc3946.room_predecessor" && ev.StateKey == "" {
+			predecessorRoomID := gjson.GetBytes(ev.JSON, "content.predecessor_room_id")
+			if predecessorRoomID.Exists() && predecessorRoomID.Type == gjson.String {
+				pred = &predecessorRoomID.Str
 			}
 		}
 		if ev.Type == "m.room.create" && ev.StateKey == "" {

--- a/state/accumulator_test.go
+++ b/state/accumulator_test.go
@@ -115,7 +115,7 @@ func TestAccumulatorAccumulate(t *testing.T) {
 	}
 	var numNew int
 	var latestNIDs []int64
-	if numNew, latestNIDs, err = accumulator.Accumulate(roomID, "", newEvents); err != nil {
+	if numNew, latestNIDs, _, err = accumulator.Accumulate(roomID, "", newEvents); err != nil {
 		t.Fatalf("failed to Accumulate: %s", err)
 	}
 	if numNew != len(newEvents) {
@@ -185,7 +185,7 @@ func TestAccumulatorAccumulate(t *testing.T) {
 	}
 
 	// subsequent calls do nothing and are not an error
-	if _, _, err = accumulator.Accumulate(roomID, "", newEvents); err != nil {
+	if _, _, _, err = accumulator.Accumulate(roomID, "", newEvents); err != nil {
 		t.Fatalf("failed to Accumulate: %s", err)
 	}
 }
@@ -207,7 +207,7 @@ func TestAccumulatorDelta(t *testing.T) {
 		[]byte(`{"event_id":"aH", "type":"m.room.join_rules", "state_key":"", "content":{"join_rule":"public"}}`),
 		[]byte(`{"event_id":"aI", "type":"m.room.history_visibility", "state_key":"", "content":{"visibility":"public"}}`),
 	}
-	if _, _, err = accumulator.Accumulate(roomID, "", roomEvents); err != nil {
+	if _, _, _, err = accumulator.Accumulate(roomID, "", roomEvents); err != nil {
 		t.Fatalf("failed to Accumulate: %s", err)
 	}
 
@@ -266,7 +266,7 @@ func TestAccumulatorMembershipLogs(t *testing.T) {
 		// @me leaves the room
 		[]byte(`{"event_id":"` + roomEventIDs[7] + `", "type":"m.room.member", "state_key":"@me:localhost","unsigned":{"prev_content":{"membership":"join", "displayname":"Me"}}, "content":{"membership":"leave"}}`),
 	}
-	if _, _, err = accumulator.Accumulate(roomID, "", roomEvents); err != nil {
+	if _, _, _, err = accumulator.Accumulate(roomID, "", roomEvents); err != nil {
 		t.Fatalf("failed to Accumulate: %s", err)
 	}
 	txn, err := accumulator.db.Beginx()
@@ -389,7 +389,7 @@ func TestAccumulatorDupeEvents(t *testing.T) {
 		t.Fatalf("failed to Initialise accumulator: %s", err)
 	}
 
-	_, _, err = accumulator.Accumulate(roomID, "", joinRoom.Timeline.Events)
+	_, _, _, err = accumulator.Accumulate(roomID, "", joinRoom.Timeline.Events)
 	if err != nil {
 		t.Fatalf("failed to Accumulate: %s", err)
 	}
@@ -434,7 +434,7 @@ func TestAccumulatorMisorderedGraceful(t *testing.T) {
 	}
 
 	// Accumulate events D, A, B(msg).
-	_, _, err = accumulator.Accumulate(roomID, "", []json.RawMessage{eventD, eventA, eventBMsg})
+	_, _, _, err = accumulator.Accumulate(roomID, "", []json.RawMessage{eventD, eventA, eventBMsg})
 	if err != nil {
 		t.Fatalf("failed to Accumulate: %s", err)
 	}

--- a/state/storage.go
+++ b/state/storage.go
@@ -318,7 +318,9 @@ func (s *Storage) currentNotMembershipStateEventsInAllRooms(txn *sqlx.Tx, eventT
 	return result, nil
 }
 
-func (s *Storage) Accumulate(roomID, prevBatch string, timeline []json.RawMessage) (numNew int, timelineNIDs []int64, err error) {
+func (s *Storage) Accumulate(roomID, prevBatch string, timeline []json.RawMessage) (
+	numNew int, timelineNIDs []int64, roomReplacements [][2]string, err error,
+) {
 	return s.accumulator.Accumulate(roomID, prevBatch, timeline)
 }
 

--- a/state/storage_test.go
+++ b/state/storage_test.go
@@ -30,7 +30,7 @@ func TestStorageRoomStateBeforeAndAfterEventPosition(t *testing.T) {
 		testutils.NewStateEvent(t, "m.room.join_rules", "", alice, map[string]interface{}{"join_rule": "invite"}),
 		testutils.NewStateEvent(t, "m.room.member", bob, alice, map[string]interface{}{"membership": "invite"}),
 	}
-	_, latestNIDs, err := store.Accumulate(roomID, "", events)
+	_, latestNIDs, _, err := store.Accumulate(roomID, "", events)
 	if err != nil {
 		t.Fatalf("Accumulate returned error: %s", err)
 	}
@@ -154,7 +154,7 @@ func TestStorageJoinedRoomsAfterPosition(t *testing.T) {
 	var latestNIDs []int64
 	var err error
 	for roomID, eventMap := range roomIDToEventMap {
-		_, latestNIDs, err = store.Accumulate(roomID, "", eventMap)
+		_, latestNIDs, _, err = store.Accumulate(roomID, "", eventMap)
 		if err != nil {
 			t.Fatalf("Accumulate on %s failed: %s", roomID, err)
 		}
@@ -339,7 +339,7 @@ func TestVisibleEventNIDsBetween(t *testing.T) {
 		},
 	}
 	for _, tl := range timelineInjections {
-		numNew, _, err := store.Accumulate(tl.RoomID, "", tl.Events)
+		numNew, _, _, err := store.Accumulate(tl.RoomID, "", tl.Events)
 		if err != nil {
 			t.Fatalf("Accumulate on %s failed: %s", tl.RoomID, err)
 		}
@@ -442,7 +442,7 @@ func TestVisibleEventNIDsBetween(t *testing.T) {
 		t.Fatalf("LatestEventNID: %s", err)
 	}
 	for _, tl := range timelineInjections {
-		numNew, _, err := store.Accumulate(tl.RoomID, "", tl.Events)
+		numNew, _, _, err := store.Accumulate(tl.RoomID, "", tl.Events)
 		if err != nil {
 			t.Fatalf("Accumulate on %s failed: %s", tl.RoomID, err)
 		}
@@ -522,7 +522,7 @@ func TestStorageLatestEventsInRoomsPrevBatch(t *testing.T) {
 	}
 	eventIDs := []string{}
 	for _, timeline := range timelines {
-		_, _, err = store.Accumulate(roomID, timeline.prevBatch, timeline.timeline)
+		_, _, _, err = store.Accumulate(roomID, timeline.prevBatch, timeline.timeline)
 		if err != nil {
 			t.Fatalf("failed to accumulate: %s", err)
 		}

--- a/sync2/handler2/handler.go
+++ b/sync2/handler2/handler.go
@@ -228,7 +228,7 @@ func (h *Handler) Accumulate(userID, deviceID, roomID, prevBatch string, timelin
 	}
 
 	// Insert new events
-	numNew, latestNIDs, err := h.Store.Accumulate(roomID, prevBatch, timeline)
+	numNew, latestNIDs, roomReplacements, err := h.Store.Accumulate(roomID, prevBatch, timeline)
 	if err != nil {
 		logger.Err(err).Int("timeline", len(timeline)).Str("room", roomID).Msg("V2: failed to accumulate room")
 		sentry.CaptureException(err)
@@ -242,6 +242,10 @@ func (h *Handler) Accumulate(userID, deviceID, roomID, prevBatch string, timelin
 		RoomID:    roomID,
 		PrevBatch: prevBatch,
 		EventNIDs: latestNIDs,
+		// TODO: for now I've just shoved this into V2Accumulate. But maybe we ought to
+		// have a new pubsub Payload type, say V2RoomReplacement dedicated to this?
+		// TODO: push this through to the V2DataReceiver and update caches on the V3 side?
+		RoomReplacements: roomReplacements,
 	})
 }
 

--- a/sync3/caches/global_test.go
+++ b/sync3/caches/global_test.go
@@ -38,12 +38,12 @@ func TestGlobalCacheLoadState(t *testing.T) {
 		testutils.NewStateEvent(t, "m.room.name", "", alice, map[string]interface{}{"name": "The Room Name"}),
 		testutils.NewStateEvent(t, "m.room.name", "", alice, map[string]interface{}{"name": "The Updated Room Name"}),
 	}
-	_, _, err := store.Accumulate(roomID2, "", eventsRoom2)
+	_, _, _, err := store.Accumulate(roomID2, "", eventsRoom2)
 	if err != nil {
 		t.Fatalf("Accumulate: %s", err)
 	}
 
-	_, latestNIDs, err := store.Accumulate(roomID, "", events)
+	_, latestNIDs, _, err := store.Accumulate(roomID, "", events)
 	if err != nil {
 		t.Fatalf("Accumulate: %s", err)
 	}


### PR DESCRIPTION
Closes https://github.com/matrix-org/sliding-sync/issues/38

Utterly WIP. I'm opening the PR for better visibility of in-flight work.

Concerns:

- What is there to stop me from marking rooms A and B as both superseding room C? At present the latest seen predecessor event wins.
- If I mark room A as superseding B1, then mark A as superseding B2, is B1 still considered to be replaced by A?
- What do we do if we learn that A supersedes B but we have no knowledge of room B? It would be a shame if we later joined B and didn't present it as being replaced by B.