### PR TITLE
Prep work for removing global load positions

### DIFF
--- a/sync3/caches/global.go
+++ b/sync3/caches/global.go
@@ -75,7 +75,7 @@ func NewGlobalCache(store *state.Storage) *GlobalCache {
 	}
 }
 
-func (c *GlobalCache) OnRegistered(_ context.Context, _ int64) error {
+func (c *GlobalCache) OnRegistered(_ context.Context) error {
 	return nil
 }
 

--- a/sync3/caches/global.go
+++ b/sync3/caches/global.go
@@ -13,9 +13,6 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-const PosAlwaysProcess = -2
-const PosDoNotProcess = -1
-
 type EventData struct {
 	Event     json.RawMessage
 	RoomID    string
@@ -37,6 +34,12 @@ type EventData struct {
 	//  - `0` used by UserCache.OnRegistered to inject space children events at startup.
 	//    It's referenced in ConnState.OnRoomUpdateand UserCache.OnSpaceUpdate
 	NID int64
+
+	// Update consumers will usually ignore updates with a NID < what they have seen before for this room.
+	// However, in some cases, we want to force the consumer to process this event even though the NID
+	// may be < what they have seen before. Currently, we use this to force consumers to process invites
+	// for a connected client, as the invite itself has no event NID due to the proxy not being in the room yet.
+	AlwaysProcess bool
 
 	// Flag set when this event should force the room contents to be resent e.g
 	// state res, initial join, etc

--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -54,9 +54,6 @@ type UserRoomData struct {
 	// Map of tag to order float.
 	// See https://spec.matrix.org/latest/client-server-api/#room-tagging
 	Tags map[string]float64
-	// LoadPos is an event NID, or a sentinal value (see EventData.NID).
-	// UserRoomData instances represent the status of this room after the corresponding event, as seen by this user.
-	LoadPos int64
 	// JoinTiming tracks our latest join to the room, excluding profile changes.
 	JoinTiming internal.EventMetadata
 }
@@ -309,7 +306,6 @@ func (c *UserCache) LazyLoadTimelines(ctx context.Context, loadPos int64, roomID
 			urd = NewUserRoomData()
 		}
 		urd.RequestedTimeline = events
-		urd.LoadPos = loadPos
 		if len(events) > 0 {
 			urd.RequestedPrevBatch = roomIDToPrevBatch[requestedRoomID]
 		}
@@ -531,7 +527,6 @@ func (c *UserCache) OnSpaceUpdate(ctx context.Context, parentRoomID, childRoomID
 func (c *UserCache) OnNewEvent(ctx context.Context, eventData *EventData) {
 	// add this to our tracked timelines if we have one
 	urd := c.LoadRoomData(eventData.RoomID)
-	urd.LoadPos = eventData.NID
 	// reset the IsInvite field when the user actually joins/rejects the invite
 	if urd.IsInvite && eventData.EventType == "m.room.member" && eventData.StateKey != nil && *eventData.StateKey == c.UserID {
 		urd.IsInvite = eventData.Content.Get("membership").Str == "invite"

--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -219,7 +219,7 @@ func (c *UserCache) Unsubscribe(id int) {
 // externally by sync3.SyncLiveHandler.userCache. It's importatn that we don't spend too
 // long inside this function, because it is called within a global lock on the
 // sync3.Dispatcher (see sync3.Dispatcher.Register).
-func (c *UserCache) OnRegistered(ctx context.Context, _ int64) error {
+func (c *UserCache) OnRegistered(ctx context.Context) error {
 	// select all spaces the user is a part of to seed the cache correctly. This has to be done in
 	// the OnRegistered callback which has locking guarantees. This is why...
 	latestPos, joinedRooms, joinTimings, err := c.globalCache.LoadJoinedRooms(ctx, c.UserID)

--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -97,13 +97,13 @@ func NewInviteData(ctx context.Context, userID, roomID string, inviteState []jso
 				ts := j.Get("origin_server_ts").Int()
 				id.LastMessageTimestamp = uint64(ts)
 				id.InviteEvent = &EventData{
-					Event:     ev,
-					RoomID:    roomID,
-					EventType: "m.room.member",
-					StateKey:  &target,
-					Content:   j.Get("content"),
-					Timestamp: uint64(ts),
-					NID:       PosAlwaysProcess,
+					Event:         ev,
+					RoomID:        roomID,
+					EventType:     "m.room.member",
+					StateKey:      &target,
+					Content:       j.Get("content"),
+					Timestamp:     uint64(ts),
+					AlwaysProcess: true,
 				}
 				id.IsDM = j.Get("is_direct").Bool()
 			} else if target == j.Get("sender").Str {

--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -606,8 +606,11 @@ func (s *ConnState) OnUpdate(ctx context.Context, up caches.Update) {
 func (s *ConnState) OnRoomUpdate(ctx context.Context, up caches.RoomUpdate) {
 	switch update := up.(type) {
 	case *caches.RoomEventUpdate:
-		if update.EventData.NID != caches.PosAlwaysProcess && update.EventData.NID == 0 {
-			// 0 -> this event was from a 'state' block, do not poke active connections
+		if !update.EventData.AlwaysProcess && update.EventData.NID == 0 {
+			// 0 -> this event was from a 'state' block, do not poke active connections.
+			// This is not the same as checking if we have already processed this event: NID=0 means
+			// it's part of initial room state. If we sent these events, we'd send them to clients in
+			// the timeline section which is wrong.
 			return
 		}
 		internal.AssertWithContext(ctx, "missing global room metadata", update.GlobalRoomMetadata() != nil)

--- a/sync3/handler/connstate_live.go
+++ b/sync3/handler/connstate_live.go
@@ -20,9 +20,6 @@ var BufferWaitTime = time.Second * 5
 type connStateLive struct {
 	*ConnState
 
-	// roomID -> latest load pos
-	loadPositions map[string]int64
-
 	// A channel which the dispatcher uses to send updates to the conn goroutine
 	// Consumed when the conn is read. There is a limit to how many updates we will store before
 	// saying the client is dead and clean up the conn.

--- a/sync3/handler/connstate_live.go
+++ b/sync3/handler/connstate_live.go
@@ -120,7 +120,7 @@ func (s *connStateLive) processLiveUpdate(ctx context.Context, up caches.Update,
 	roomEventUpdate, _ := up.(*caches.RoomEventUpdate)
 	// if this is a room event update we may not want to process this if the event nid is < loadPos,
 	// as that means we have already taken it into account
-	if roomEventUpdate != nil && roomEventUpdate.EventData.NID != caches.PosAlwaysProcess && roomEventUpdate.EventData.NID < s.loadPosition {
+	if roomEventUpdate != nil && !roomEventUpdate.EventData.AlwaysProcess && roomEventUpdate.EventData.NID < s.loadPosition {
 		return false
 	}
 


### PR DESCRIPTION
Remove unused fields, and moved `loadPositions` to its final place.