### PR TITLE
Ignore txn_id when comparing request bodies

### DIFF
--- a/sync3/conn_test.go
+++ b/sync3/conn_test.go
@@ -201,14 +201,15 @@ func TestConnBufferRes(t *testing.T) {
 	assertPos(t, resp.Pos, 2)
 	assertInt(t, resp.Lists["a"].Count, 2)
 	assertInt(t, callCount, 2)
-	// retry with modified request data, should invoke handler again!
-	resp, err = c.OnIncomingRequest(ctx, &Request{pos: 1, TxnID: "a"})
+	// retry with modified request data that shouldn't prompt data to be returned.
+	// should invoke handler again!
+	resp, err = c.OnIncomingRequest(ctx, &Request{pos: 1, UnsubscribeRooms: []string{"a"}})
 	assertNoError(t, err)
 	assertPos(t, resp.Pos, 2)
 	assertInt(t, resp.Lists["a"].Count, 2)
 	assertInt(t, callCount, 3) // this DOES increment, the response is buffered and not returned yet.
 	// retry with same request body, so should NOT invoke handler again and return buffered response
-	resp, err = c.OnIncomingRequest(ctx, &Request{pos: 2, TxnID: "a"})
+	resp, err = c.OnIncomingRequest(ctx, &Request{pos: 2, UnsubscribeRooms: []string{"a"}})
 	assertNoError(t, err)
 	assertPos(t, resp.Pos, 3)
 	assertInt(t, resp.Lists["a"].Count, 3)
@@ -314,43 +315,43 @@ func TestConnBufferRememberInflight(t *testing.T) {
 			wantCallCount: 2,
 		},
 		{ // lost HTTP response, cancelled request, new params, returns buffered response but does execute handler
-			req:           &Request{pos: 1, TxnID: "a"},
+			req:           &Request{pos: 1, UnsubscribeRooms: []string{"a"}},
 			wantResPos:    2,
 			wantResCount:  2,
 			wantCallCount: 3,
 		},
 		{ // lost HTTP response, cancelled request, new params, returns same buffered response but does execute handler again
-			req:           &Request{pos: 1, TxnID: "b"},
+			req:           &Request{pos: 1, UnsubscribeRooms: []string{"b"}},
 			wantResPos:    2,
 			wantResCount:  2,
 			wantCallCount: 4,
 		},
 		{ // lost HTTP response, cancelled request, new params, returns same buffered response but does execute handler again
-			req:           &Request{pos: 1, TxnID: "c"},
+			req:           &Request{pos: 1, UnsubscribeRooms: []string{"c"}},
 			wantResPos:    2,
 			wantResCount:  2,
 			wantCallCount: 5,
 		},
 		{ // response returned, params same now, begin consuming buffer..
-			req:           &Request{pos: 2, TxnID: "c"},
+			req:           &Request{pos: 2, UnsubscribeRooms: []string{"c"}},
 			wantResPos:    3,
 			wantResCount:  3,
 			wantCallCount: 5,
 		},
 		{ // response returned, params same now, begin consuming buffer..
-			req:           &Request{pos: 3, TxnID: "c"},
+			req:           &Request{pos: 3, UnsubscribeRooms: []string{"c"}},
 			wantResPos:    4,
 			wantResCount:  4,
 			wantCallCount: 5,
 		},
 		{ // response returned, params same now, begin consuming buffer..
-			req:           &Request{pos: 4, TxnID: "c"},
+			req:           &Request{pos: 4, UnsubscribeRooms: []string{"c"}},
 			wantResPos:    5,
 			wantResCount:  5,
 			wantCallCount: 5,
 		},
 		{ // response lost, should send buffered response if it isn't just doing the latest one (which is pos=5)
-			req:           &Request{pos: 4, TxnID: "c"},
+			req:           &Request{pos: 4, UnsubscribeRooms: []string{"c"}},
 			wantResPos:    5,
 			wantResCount:  5,
 			wantCallCount: 5,

--- a/sync3/request.go
+++ b/sync3/request.go
@@ -270,12 +270,20 @@ func (r *Request) SetTimeoutMSecs(timeout int) {
 	r.timeoutMSecs = timeout
 }
 
+// Same determines if the given request would produce the same output as the other
+// if given the same input data.
 func (r *Request) Same(other *Request) bool {
-	serialised, err := json.Marshal(r)
+	// If a client changes nothing but the txn_id field, we need to consider the
+	// requests the same. Therefore we blank out the txn_id before marshaling.
+	rCopy := *r
+	otherCopy := *other
+	rCopy.TxnID = ""
+	otherCopy.TxnID = ""
+	serialised, err := json.Marshal(rCopy)
 	if err != nil {
 		return false
 	}
-	otherSer, err := json.Marshal(other)
+	otherSer, err := json.Marshal(otherCopy)
 	if err != nil {
 		return false
 	}

--- a/sync3/request_test.go
+++ b/sync3/request_test.go
@@ -1002,6 +1002,57 @@ func TestRequestList_CalculateMoveIndexes(t *testing.T) {
 	}
 }
 
+func TestSame(t *testing.T) {
+	cases := []struct {
+		a          Request
+		b          Request
+		expectSame bool
+	}{
+		{
+			a:          Request{},
+			b:          Request{},
+			expectSame: true,
+		},
+		{
+			a: Request{
+				TxnID:        "txn1",
+				ConnID:       "conn",
+				pos:          10,
+				timeoutMSecs: 30000,
+			},
+			b: Request{
+				TxnID:        "txn2",
+				ConnID:       "conn",
+				pos:          10,
+				timeoutMSecs: 30000,
+			},
+			expectSame: true,
+		},
+		{
+			a: Request{
+				TxnID:        "txn1",
+				ConnID:       "conn1",
+				pos:          10,
+				timeoutMSecs: 30000,
+			},
+			b: Request{
+				TxnID:        "txn2",
+				ConnID:       "conn2",
+				pos:          10,
+				timeoutMSecs: 30000,
+			},
+			expectSame: false,
+		},
+	}
+
+	for i, testcase := range cases {
+		isSame := testcase.a.Same(&testcase.b)
+		if isSame != testcase.expectSame {
+			t.Errorf("case %d: expected same %t but got %t", i, testcase.expectSame, isSame)
+		}
+	}
+}
+
 func TestRequestList_WriteDeleteOp(t *testing.T) {
 	noIndex := -1
 	testCases := []struct {

--- a/sync3/request_test.go
+++ b/sync3/request_test.go
@@ -1008,11 +1008,13 @@ func TestSame(t *testing.T) {
 		b          Request
 		expectSame bool
 	}{
+		// Two zero structs are the Same.
 		{
 			a:          Request{},
 			b:          Request{},
 			expectSame: true,
 		},
+		// Requests only differing in txn ID are the same.
 		{
 			a: Request{
 				TxnID:        "txn1",
@@ -1028,6 +1030,9 @@ func TestSame(t *testing.T) {
 			},
 			expectSame: true,
 		},
+		// Requests only differing in some other field ConnID are NOT the same.
+		// TODO: would be better to change a more important field like lists rather than
+		// ConnID.
 		{
 			a: Request{
 				TxnID:        "txn1",


### PR DESCRIPTION
This should avoid a tight loop seen with EX clients now that they are always sending txn_ids.