### PR TITLE
Reduce DB conn pressure when handling new tokens

### DIFF
--- a/sync2/devices_table.go
+++ b/sync2/devices_table.go
@@ -32,8 +32,8 @@ func NewDevicesTable(db *sqlx.DB) *DevicesTable {
 
 // InsertDevice creates a new devices row with a blank since token if no such row
 // exists. Otherwise, it does nothing.
-func (t *DevicesTable) InsertDevice(userID, deviceID string) error {
-	_, err := t.db.Exec(
+func (t *DevicesTable) InsertDevice(txn *sqlx.Tx, userID, deviceID string) error {
+	_, err := txn.Exec(
 		` INSERT INTO syncv3_sync2_devices(user_id, device_id, since) VALUES($1,$2,$3)
 		ON CONFLICT (user_id, device_id) DO NOTHING`,
 		userID, deviceID, "",

--- a/sync2/tokens_table.go
+++ b/sync2/tokens_table.go
@@ -171,10 +171,10 @@ func (t *TokensTable) TokenForEachDevice(txn *sqlx.Tx) (tokens []TokenForPoller,
 }
 
 // Insert a new token into the table.
-func (t *TokensTable) Insert(plaintextToken, userID, deviceID string, lastSeen time.Time) (*Token, error) {
+func (t *TokensTable) Insert(txn *sqlx.Tx, plaintextToken, userID, deviceID string, lastSeen time.Time) (*Token, error) {
 	hashedToken := hashToken(plaintextToken)
 	encToken := t.encrypt(plaintextToken)
-	_, err := t.db.Exec(
+	_, err := txn.Exec(
 		`INSERT INTO syncv3_sync2_tokens(token_hash, token_encrypted, user_id, device_id, last_seen)
 		VALUES ($1, $2, $3, $4, $5)
 		ON CONFLICT (token_hash) DO NOTHING;`,

--- a/sync2/tokens_table_test.go
+++ b/sync2/tokens_table_test.go
@@ -29,10 +29,10 @@ func TestTokensTable(t *testing.T) {
 	aliceToken1FirstSeen := time.Now()
 
 	var aliceToken, reinsertedToken *Token
-	_ = sqlutil.WithTransaction(db, func(txn *sqlx.Tx) error {
+	_ = sqlutil.WithTransaction(db, func(txn *sqlx.Tx) (err error) {
 		// Test a single token
 		t.Log("Insert a new token from Alice.")
-		aliceToken, err := tokens.Insert(txn, aliceSecret1, alice, aliceDevice, aliceToken1FirstSeen)
+		aliceToken, err = tokens.Insert(txn, aliceSecret1, alice, aliceDevice, aliceToken1FirstSeen)
 		if err != nil {
 			t.Fatalf("Failed to Insert token: %s", err)
 		}

--- a/sync2/tokens_table_test.go
+++ b/sync2/tokens_table_test.go
@@ -1,6 +1,8 @@
 package sync2
 
 import (
+	"github.com/jmoiron/sqlx"
+	"github.com/matrix-org/sliding-sync/sqlutil"
 	"testing"
 	"time"
 )
@@ -26,27 +28,31 @@ func TestTokensTable(t *testing.T) {
 	aliceSecret1 := "mysecret1"
 	aliceToken1FirstSeen := time.Now()
 
-	// Test a single token
-	t.Log("Insert a new token from Alice.")
-	aliceToken, err := tokens.Insert(aliceSecret1, alice, aliceDevice, aliceToken1FirstSeen)
-	if err != nil {
-		t.Fatalf("Failed to Insert token: %s", err)
-	}
+	var aliceToken, reinsertedToken *Token
+	_ = sqlutil.WithTransaction(db, func(txn *sqlx.Tx) error {
+		// Test a single token
+		t.Log("Insert a new token from Alice.")
+		aliceToken, err := tokens.Insert(txn, aliceSecret1, alice, aliceDevice, aliceToken1FirstSeen)
+		if err != nil {
+			t.Fatalf("Failed to Insert token: %s", err)
+		}
 
-	t.Log("The returned Token struct should have been populated correctly.")
-	assertEqualTokens(t, tokens, aliceToken, aliceSecret1, alice, aliceDevice, aliceToken1FirstSeen)
+		t.Log("The returned Token struct should have been populated correctly.")
+		assertEqualTokens(t, tokens, aliceToken, aliceSecret1, alice, aliceDevice, aliceToken1FirstSeen)
 
-	t.Log("Reinsert the same token.")
-	reinsertedToken, err := tokens.Insert(aliceSecret1, alice, aliceDevice, aliceToken1FirstSeen)
-	if err != nil {
-		t.Fatalf("Failed to Insert token: %s", err)
-	}
+		t.Log("Reinsert the same token.")
+		reinsertedToken, err = tokens.Insert(txn, aliceSecret1, alice, aliceDevice, aliceToken1FirstSeen)
+		if err != nil {
+			t.Fatalf("Failed to Insert token: %s", err)
+		}
+		return nil
+	})
 
 	t.Log("This should yield an equal Token struct.")
 	assertEqualTokens(t, tokens, reinsertedToken, aliceSecret1, alice, aliceDevice, aliceToken1FirstSeen)
 
 	t.Log("Try to mark Alice's token as being used after an hour.")
-	err = tokens.MaybeUpdateLastSeen(aliceToken, aliceToken1FirstSeen.Add(time.Hour))
+	err := tokens.MaybeUpdateLastSeen(aliceToken, aliceToken1FirstSeen.Add(time.Hour))
 	if err != nil {
 		t.Fatalf("Failed to update last seen: %s", err)
 	}
@@ -74,17 +80,20 @@ func TestTokensTable(t *testing.T) {
 	}
 	assertEqualTokens(t, tokens, fetchedToken, aliceSecret1, alice, aliceDevice, aliceToken1LastSeen)
 
-	// Test a second token for Alice
-	t.Log("Insert a second token for Alice.")
-	aliceSecret2 := "mysecret2"
-	aliceToken2FirstSeen := aliceToken1LastSeen.Add(time.Minute)
-	aliceToken2, err := tokens.Insert(aliceSecret2, alice, aliceDevice, aliceToken2FirstSeen)
-	if err != nil {
-		t.Fatalf("Failed to Insert token: %s", err)
-	}
+	_ = sqlutil.WithTransaction(db, func(txn *sqlx.Tx) error {
+		// Test a second token for Alice
+		t.Log("Insert a second token for Alice.")
+		aliceSecret2 := "mysecret2"
+		aliceToken2FirstSeen := aliceToken1LastSeen.Add(time.Minute)
+		aliceToken2, err := tokens.Insert(txn, aliceSecret2, alice, aliceDevice, aliceToken2FirstSeen)
+		if err != nil {
+			t.Fatalf("Failed to Insert token: %s", err)
+		}
 
-	t.Log("The returned Token struct should have been populated correctly.")
-	assertEqualTokens(t, tokens, aliceToken2, aliceSecret2, alice, aliceDevice, aliceToken2FirstSeen)
+		t.Log("The returned Token struct should have been populated correctly.")
+		assertEqualTokens(t, tokens, aliceToken2, aliceSecret2, alice, aliceDevice, aliceToken2FirstSeen)
+		return nil
+	})
 }
 
 func TestDeletingTokens(t *testing.T) {
@@ -94,11 +103,15 @@ func TestDeletingTokens(t *testing.T) {
 
 	t.Log("Insert a new token from Alice.")
 	accessToken := "mytoken"
-	token, err := tokens.Insert(accessToken, "@bob:builders.com", "device", time.Time{})
-	if err != nil {
-		t.Fatalf("Failed to Insert token: %s", err)
-	}
 
+	var token *Token
+	err := sqlutil.WithTransaction(db, func(txn *sqlx.Tx) (err error) {
+		token, err = tokens.Insert(txn, accessToken, "@bob:builders.com", "device", time.Time{})
+		if err != nil {
+			t.Fatalf("Failed to Insert token: %s", err)
+		}
+		return nil
+	})
 	t.Log("We should be able to fetch this token without error.")
 	_, err = tokens.Token(accessToken)
 	if err != nil {

--- a/sync3/handler/handler.go
+++ b/sync3/handler/handler.go
@@ -420,14 +420,14 @@ func (h *SyncLiveHandler) identifyUnknownAccessToken(accessToken string, logger 
 	var token *sync2.Token
 	err = sqlutil.WithTransaction(h.V2Store.DB, func(txn *sqlx.Tx) error {
 		// Create a brand-new row for this token.
-		token, err = h.V2Store.TokensTable.Insert(accessToken, userID, deviceID, time.Now())
+		token, err = h.V2Store.TokensTable.Insert(txn, accessToken, userID, deviceID, time.Now())
 		if err != nil {
 			logger.Warn().Err(err).Str("user", userID).Str("device", deviceID).Msg("failed to insert v2 token")
 			return err
 		}
 
 		// Ensure we have a device row for this token.
-		err = h.V2Store.DevicesTable.InsertDevice(userID, deviceID)
+		err = h.V2Store.DevicesTable.InsertDevice(txn, userID, deviceID)
 		if err != nil {
 			log.Warn().Err(err).Str("user", userID).Str("device", deviceID).Msg("failed to insert v2 device")
 			return err


### PR DESCRIPTION
The intent was to insert token and device in a single transaction, to avoid situations where we've persisted one of these facts but not the other.

Unfortunately this is not what the code actually does as written. We don't use the txn at all! So we will use 1 conn for the txn and another conn for the actual queries.