### PR TITLE
Debug missing roomIDs/event timestamps seen at startup

### DIFF
--- a/sync3/caches/global.go
+++ b/sync3/caches/global.go
@@ -239,8 +239,13 @@ func (c *GlobalCache) Startup(roomIDToMetadata map[string]internal.RoomMetadata)
 	sort.Strings(roomIDs)
 	for _, roomID := range roomIDs {
 		metadata := roomIDToMetadata[roomID]
-		internal.Assert("room ID is set", metadata.RoomID != "")
-		internal.Assert("last message timestamp exists", metadata.LastMessageTimestamp > 1)
+		debugContext := map[string]interface{}{
+			"room_id":                       roomID,
+			"metadata.RoomID":               metadata.RoomID,
+			"metadata.LastMessageTimeStamp": metadata.LastMessageTimestamp,
+		}
+		internal.Assert("room ID is set", metadata.RoomID != "", debugContext)
+		internal.Assert("last message timestamp exists", metadata.LastMessageTimestamp > 1, debugContext)
 		c.roomIDToMetadata[roomID] = &metadata
 	}
 	return nil


### PR DESCRIPTION
Sentry: https://sentry.tools.element.io/organizations/element/issues/70026/events/7080aeab1d0b402e987a18f26c1ac329/?project=56&query=is%3Aunresolved

```
github.com/matrix-org/sliding-sync@v0.99.4-0.20230619174814-fc1fce54e4cd/internal/errors.go in Assert at line 77
github.com/matrix-org/sliding-sync@v0.99.4-0.20230619174814-fc1fce54e4cd/sync3/caches/global.go in (*GlobalCache).Startup at line 242
github.com/matrix-org/sliding-sync@v0.99.4-0.20230619174814-fc1fce54e4cd/sync3/handler/handler.go in (*SyncLiveHandler).Startup at line 105
```

This has been seen for as long as we've had sentry reporting.

It's not clear to me if this has any negative consequences, but I would still like to understand wtf is going on here.

https://github.com/matrix-org/sliding-sync/blob/f699eabeedea2b7e00ffd5dd6a918f88ec2f90d9/sync3/caches/global.go#L222-L253

AFAICS the elements of `roomIDs` shouldbe exactly the keys of `roomIDToMetadata`. (We hold the mutex on roomIDToMetadata----I suppose something could be modifying it underneath us that's not playing by the rules and aquiring the lock.)

This suggests then that there is a duff value in roomIDToMetadata somewhere. I would like to know what the room IDs are so I can rule out there being dodgy data.
