### PR TITLE
Increase timeout of init sync to 30mn for small homeservers

### DIFF
--- a/sync2/client.go
+++ b/sync2/client.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/tidwall/gjson"
@@ -69,7 +70,15 @@ func (v *HTTPClient) DoSyncV2(ctx context.Context, accessToken, since string, is
 	if err != nil {
 		return nil, 0, fmt.Errorf("DoSyncV2: NewRequest failed: %w", err)
 	}
-	res, err := v.Client.Do(req)
+	var res *http.Response
+	if isFirst {
+		longTimeoutClient := &http.Client{
+			Timeout: 30 * time.Minute,
+		}
+		res, err = longTimeoutClient.Do(req)
+	} else {
+		res, err = v.Client.Do(req)
+	}
 	if err != nil {
 		return nil, 0, fmt.Errorf("DoSyncV2: request failed: %w", err)
 	}

--- a/v3.go
+++ b/v3.go
@@ -73,7 +73,7 @@ func Setup(destHomeserver, postgresURI, secret string, opts Opts) (*handler2.Han
 	// Setup shared DB and HTTP client
 	v2Client := &sync2.HTTPClient{
 		Client: &http.Client{
-			Timeout: 45 * time.Second,
+			Timeout: 5 * time.Minute,
 		},
 		DestinationServer: destHomeserver,
 	}

--- a/v3.go
+++ b/v3.go
@@ -73,7 +73,7 @@ func Setup(destHomeserver, postgresURI, secret string, opts Opts) (*handler2.Han
 	// Setup shared DB and HTTP client
 	v2Client := &sync2.HTTPClient{
 		Client: &http.Client{
-			Timeout: 5 * time.Minute,
+			Timeout: 45 * time.Second,
 		},
 		DestinationServer: destHomeserver,
 	}


### PR DESCRIPTION
The default client is then only used for incremental syncs with a 30s timeout, so decrease the default client timeout to 45s.

Signed-off-by: Mathieu Velten <mathieuv@matrix.org>

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

