### PR TITLE
Give clients avatar URLs for rooms

### DIFF
--- a/internal/roomname.go
+++ b/internal/roomname.go
@@ -30,6 +30,7 @@ type RoomMetadata struct {
 	RoomID         string
 	Heroes         []Hero
 	NameEvent      string // the content of m.room.name, NOT the calculated name
+	AvatarEvent    string // the content of m.room.avatar, NOT the resolved avatar
 	CanonicalAlias string
 	JoinCount      int
 	InviteCount    int

--- a/internal/roomname.go
+++ b/internal/roomname.go
@@ -13,7 +13,12 @@ type EventMetadata struct {
 	Timestamp uint64
 }
 
-// RoomMetadata holds room-scoped data. It is primarily used in two places:
+// RoomMetadata holds room-scoped data.
+// TODO: This is a lie: we sometimes remove a user U from the list of heroes
+// when calculating the sync response for that user U. Grep for `RemoveHero`.
+//
+// It is primarily used in two places:
+//
 //   - in the caches.GlobalCache, to hold the latest version of data that is consistent
 //     between all users in the room; and
 //   - in the sync3.RoomConnMetadata struct, to hold the version of data last seen by
@@ -52,6 +57,32 @@ func NewRoomMetadata(roomID string) *RoomMetadata {
 		LatestEventsByType: make(map[string]EventMetadata),
 		ChildSpaceRooms:    make(map[string]struct{}),
 	}
+}
+
+// CopyHeroes returns a version of the current RoomMetadata whose Heroes field is
+// a brand-new copy of the original Heroes. The return value's Heroes field can be
+// safely modified by the caller, but it is NOT safe for the caller to modify any other
+// fields.
+func (m *RoomMetadata) CopyHeroes() *RoomMetadata {
+	newMetadata := *m
+
+	// XXX: We're doing this because we end up calling RemoveHero() to omit the
+	// currently-sycning user in various places. But this seems smelly. The set of
+	// heroes in the room is a global, room-scoped fact: it is a property of the room
+	// state and nothing else, and all users see the same set of heroes.
+	//
+	// I think the data model would be cleaner if we made the hero-reading functions
+	// aware of the currently syncing user, in order to ignore them without having to
+	// change the underlying data.
+	//
+	// copy the heroes or else we may modify the same slice which would be bad :(
+	newMetadata.Heroes = make([]Hero, len(m.Heroes))
+	copy(newMetadata.Heroes, m.Heroes)
+
+	// ⚠️ NB: there are other pointer fields (e.g. PredecessorRoomID *string) or
+	// and pointer-backed fields (e.g. LatestEventsByType map[string]EventMetadata)
+	// which are not deepcopied here.
+	return &newMetadata
 }
 
 // SameRoomName checks if the fields relevant for room names have changed between the two metadatas.

--- a/internal/roomname.go
+++ b/internal/roomname.go
@@ -244,3 +244,18 @@ func disambiguate(heroes []Hero) []string {
 	}
 	return disambiguatedNames
 }
+
+const noAvatar = ""
+
+// CalculateAvatar computes the avatar for the room, based on the global room metadata.
+// Assumption: metadata.RemoveHero has been called to remove the user who is syncing
+// from the list of heroes.
+func CalculateAvatar(metadata *RoomMetadata) string {
+	if metadata.AvatarEvent != "" {
+		return metadata.AvatarEvent
+	}
+	if len(metadata.Heroes) == 1 {
+		return metadata.Heroes[0].Avatar
+	}
+	return noAvatar
+}

--- a/internal/roomname.go
+++ b/internal/roomname.go
@@ -94,7 +94,13 @@ func (m *RoomMetadata) SameRoomName(other *RoomMetadata) bool {
 		m.CanonicalAlias == other.CanonicalAlias &&
 		m.JoinCount == other.JoinCount &&
 		m.InviteCount == other.InviteCount &&
-		sameHeroes(m.Heroes, other.Heroes))
+		sameHeroNames(m.Heroes, other.Heroes))
+}
+
+// SameRoomAvatar checks if the fields relevant for room avatars have changed between the two metadatas.
+// Returns true if there are no changes.
+func (m *RoomMetadata) SameRoomAvatar(other *RoomMetadata) bool {
+	return m.AvatarEvent == other.AvatarEvent && sameHeroAvatars(m.Heroes, other.Heroes)
 }
 
 func (m *RoomMetadata) SameJoinCount(other *RoomMetadata) bool {
@@ -105,7 +111,7 @@ func (m *RoomMetadata) SameInviteCount(other *RoomMetadata) bool {
 	return m.InviteCount == other.InviteCount
 }
 
-func sameHeroes(a, b []Hero) bool {
+func sameHeroNames(a, b []Hero) bool {
 	if len(a) != len(b) {
 		return false
 	}
@@ -114,6 +120,21 @@ func sameHeroes(a, b []Hero) bool {
 			return false
 		}
 		if a[i].Name != b[i].Name {
+			return false
+		}
+	}
+	return true
+}
+
+func sameHeroAvatars(a, b []Hero) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].ID != b[i].ID {
+			return false
+		}
+		if a[i].Avatar != b[i].Avatar {
 			return false
 		}
 	}
@@ -134,8 +155,9 @@ func (m *RoomMetadata) IsSpace() bool {
 }
 
 type Hero struct {
-	ID   string
-	Name string
+	ID     string
+	Name   string
+	Avatar string
 }
 
 func CalculateRoomName(heroInfo *RoomMetadata, maxNumNamesPerRoom int) string {

--- a/internal/roomname_test.go
+++ b/internal/roomname_test.go
@@ -247,3 +247,45 @@ func TestCalculateRoomName(t *testing.T) {
 		}
 	}
 }
+
+func TestCopyHeroes(t *testing.T) {
+	const alice = "@alice:test"
+	const bob = "@bob:test"
+	const chris = "@chris:test"
+	m1 := RoomMetadata{Heroes: []Hero{
+		{ID: alice},
+		{ID: bob},
+		{ID: chris},
+	}}
+
+	m2 := m1.CopyHeroes()
+	// Uncomment this to see why CopyHeroes is necessary!
+	//m2 := m1
+
+	t.Logf("Compare heroes:\n\tm1=%v\n\tm2=%v", m1.Heroes, m2.Heroes)
+
+	t.Log("Remove chris from m1")
+	m1.RemoveHero(chris)
+	t.Logf("Compare heroes:\n\tm1=%v\n\tm2=%v", m1.Heroes, m2.Heroes)
+
+	assertSliceIDs(t, "m1.Heroes", m1.Heroes, []string{alice, bob})
+	assertSliceIDs(t, "m2.Heroes", m2.Heroes, []string{alice, bob, chris})
+
+	t.Log("Remove alice from m1")
+	m1.RemoveHero(alice)
+	t.Logf("Compare heroes:\n\tm1=%v\n\tm2=%v", m1.Heroes, m2.Heroes)
+
+	assertSliceIDs(t, "m1.Heroes", m1.Heroes, []string{bob})
+	assertSliceIDs(t, "m2.Heroes", m2.Heroes, []string{alice, bob, chris})
+}
+
+func assertSliceIDs(t *testing.T, desc string, h []Hero, ids []string) {
+	if len(h) != len(ids) {
+		t.Errorf("%s has length %d, expected %d", desc, len(h), len(ids))
+	}
+	for index, id := range ids {
+		if h[index].ID != id {
+			t.Errorf("%s[%d] ID is %s, expected %s", desc, index, h[index].ID, id)
+		}
+	}
+}

--- a/state/storage.go
+++ b/state/storage.go
@@ -232,7 +232,7 @@ func (s *Storage) MetadataForAllRooms(txn *sqlx.Tx, tempTableName string, result
 
 	// Select the name / canonical alias for all rooms
 	roomIDToStateEvents, err := s.currentNotMembershipStateEventsInAllRooms(txn, []string{
-		"m.room.name", "m.room.canonical_alias",
+		"m.room.name", "m.room.canonical_alias", "m.room.avatar",
 	})
 	if err != nil {
 		return fmt.Errorf("failed to load state events for all rooms: %s", err)
@@ -244,6 +244,8 @@ func (s *Storage) MetadataForAllRooms(txn *sqlx.Tx, tempTableName string, result
 				metadata.NameEvent = gjson.ParseBytes(ev.JSON).Get("content.name").Str
 			} else if ev.Type == "m.room.canonical_alias" && ev.StateKey == "" {
 				metadata.CanonicalAlias = gjson.ParseBytes(ev.JSON).Get("content.alias").Str
+			} else if ev.Type == "m.room.avatar" && ev.StateKey == "" {
+				metadata.AvatarEvent = gjson.ParseBytes(ev.JSON).Get("content.url").Str
 			}
 		}
 		result[roomID] = metadata

--- a/state/storage.go
+++ b/state/storage.go
@@ -284,8 +284,9 @@ func (s *Storage) MetadataForAllRooms(txn *sqlx.Tx, tempTableName string, result
 		seen[key] = true
 		metadata := result[roomID]
 		metadata.Heroes = append(metadata.Heroes, internal.Hero{
-			ID:   targetUser,
-			Name: ev.Get("content.displayname").Str,
+			ID:     targetUser,
+			Name:   ev.Get("content.displayname").Str,
+			Avatar: ev.Get("content.avatar_url").Str,
 		})
 		result[roomID] = metadata
 	}

--- a/sync3/avatar.go
+++ b/sync3/avatar.go
@@ -1,0 +1,42 @@
+package sync3
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// An AvatarChange represents a change to a room's avatar. There are three cases:
+//   - an empty string represents no change, and should be omitted when JSON-serialised;
+//   - the sentinel `<no-avatar>` represents a room that has never had an avatar,
+//     or a room whose avatar has been removed. It is JSON-serialised as null.
+//   - All other strings represent the current avatar of the room and JSON-serialise as
+//     normal.
+type AvatarChange string
+
+const DeletedAvatar = AvatarChange("<no-avatar>")
+const UnchangedAvatar AvatarChange = ""
+
+// NewAvatarChange interprets an optional avatar string as an AvatarChange.
+func NewAvatarChange(avatar string) AvatarChange {
+	if avatar == "" {
+		return DeletedAvatar
+	}
+	return AvatarChange(avatar)
+}
+
+func (a AvatarChange) MarshalJSON() ([]byte, error) {
+	if a == DeletedAvatar {
+		return []byte(`null`), nil
+	} else {
+		return json.Marshal(string(a))
+	}
+}
+
+// Note: the unmarshalling is only used in tests.
+func (a *AvatarChange) UnmarshalJSON(data []byte) error {
+	if bytes.Equal(data, []byte("null")) {
+		*a = DeletedAvatar
+		return nil
+	}
+	return json.Unmarshal(data, (*string)(a))
+}

--- a/sync3/caches/global.go
+++ b/sync3/caches/global.go
@@ -279,6 +279,10 @@ func (c *GlobalCache) OnNewEvent(
 		if ed.StateKey != nil && *ed.StateKey == "" {
 			metadata.NameEvent = ed.Content.Get("name").Str
 		}
+	case "m.room.avatar":
+		if ed.StateKey != nil && *ed.StateKey == "" {
+			metadata.AvatarEvent = ed.Content.Get("url").Str
+		}
 	case "m.room.encryption":
 		if ed.StateKey != nil && *ed.StateKey == "" {
 			metadata.Encrypted = true

--- a/sync3/caches/global.go
+++ b/sync3/caches/global.go
@@ -118,13 +118,7 @@ func (c *GlobalCache) copyRoom(roomID string) *internal.RoomMetadata {
 		logger.Warn().Str("room", roomID).Msg("GlobalCache.LoadRoom: no metadata for this room, returning stub")
 		return internal.NewRoomMetadata(roomID)
 	}
-	srCopy := *sr
-	// copy the heroes or else we may modify the same slice which would be bad :(
-	srCopy.Heroes = make([]internal.Hero, len(sr.Heroes))
-	for i := range sr.Heroes {
-		srCopy.Heroes[i] = sr.Heroes[i]
-	}
-	return &srCopy
+	return sr.CopyHeroes()
 }
 
 // LoadJoinedRooms loads all current joined room metadata for the user given, together

--- a/sync3/caches/global.go
+++ b/sync3/caches/global.go
@@ -347,14 +347,16 @@ func (c *GlobalCache) OnNewEvent(
 				for i := range metadata.Heroes {
 					if metadata.Heroes[i].ID == *ed.StateKey {
 						metadata.Heroes[i].Name = ed.Content.Get("displayname").Str
+						metadata.Heroes[i].Avatar = ed.Content.Get("avatar_url").Str
 						found = true
 						break
 					}
 				}
 				if !found {
 					metadata.Heroes = append(metadata.Heroes, internal.Hero{
-						ID:   *ed.StateKey,
-						Name: ed.Content.Get("displayname").Str,
+						ID:     *ed.StateKey,
+						Name:   ed.Content.Get("displayname").Str,
+						Avatar: ed.Content.Get("avatar_url").Str,
 					})
 				}
 			}

--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -328,7 +328,10 @@ func (c *UserCache) LoadRoomData(roomID string) UserRoomData {
 }
 
 type roomUpdateCache struct {
-	roomID         string
+	roomID string
+	// globalRoomData is a snapshot of the global metadata for this room immediately
+	// after this update. It is a copy, specific to the given user whose Heroes
+	// field can be freely modified.
 	globalRoomData *internal.RoomMetadata
 	userRoomData   *UserRoomData
 }

--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -46,7 +46,7 @@ type UserRoomData struct {
 	// The zero value of this safe to use (0 latest nid, no prev batch, no timeline).
 	RequestedLatestEvents state.LatestEvents
 
-	// TODO: should Canonicalised really be in RoomConMetadata? It's only set in SetRoom AFAICS
+	// TODO: should CanonicalisedName really be in RoomConMetadata? It's only set in SetRoom AFAICS
 	CanonicalisedName string // stripped leading symbols like #, all in lower case
 	// Set of spaces this room is a part of, from the perspective of this user. This is NOT global room data
 	// as the set of spaces may be different for different users.

--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -125,7 +125,7 @@ func NewInviteData(ctx context.Context, userID, roomID string, inviteState []jso
 		case "m.room.name":
 			id.NameEvent = j.Get("content.name").Str
 		case "m.room.avatar":
-			id.AvatarEvent = j.Get("content.avatar_url").Str
+			id.AvatarEvent = j.Get("content.url").Str
 		case "m.room.canonical_alias":
 			id.CanonicalAlias = j.Get("content.alias").Str
 		case "m.room.encryption":

--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -73,6 +73,7 @@ type InviteData struct {
 	Heroes               []internal.Hero
 	InviteEvent          *EventData
 	NameEvent            string // the content of m.room.name, NOT the calculated name
+	AvatarEvent          string // the content of m.room.avatar, NOT the calculated avatar
 	CanonicalAlias       string
 	LastMessageTimestamp uint64
 	Encrypted            bool
@@ -114,6 +115,8 @@ func NewInviteData(ctx context.Context, userID, roomID string, inviteState []jso
 			}
 		case "m.room.name":
 			id.NameEvent = j.Get("content.name").Str
+		case "m.room.avatar":
+			id.AvatarEvent = j.Get("content.avatar_url").Str
 		case "m.room.canonical_alias":
 			id.CanonicalAlias = j.Get("content.alias").Str
 		case "m.room.encryption":
@@ -147,6 +150,7 @@ func (i *InviteData) RoomMetadata() *internal.RoomMetadata {
 	metadata := internal.NewRoomMetadata(i.roomID)
 	metadata.Heroes = i.Heroes
 	metadata.NameEvent = i.NameEvent
+	metadata.AvatarEvent = i.AvatarEvent
 	metadata.CanonicalAlias = i.CanonicalAlias
 	metadata.InviteCount = 1
 	metadata.JoinCount = 1

--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -225,7 +225,7 @@ func (c *UserCache) Unsubscribe(id int) {
 // OnRegistered is called after the sync3.Dispatcher has successfully registered this
 // cache to receive updates. We use this to run some final initialisation logic that
 // is sensitive to race conditions; confusingly, most of the initialisation is driven
-// externally by sync3.SyncLiveHandler.userCache. It's importatn that we don't spend too
+// externally by sync3.SyncLiveHandler.userCaches. It's important that we don't spend too
 // long inside this function, because it is called within a global lock on the
 // sync3.Dispatcher (see sync3.Dispatcher.Register).
 func (c *UserCache) OnRegistered(ctx context.Context) error {

--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -50,6 +50,14 @@ type UserRoomData struct {
 	CanonicalisedName string // stripped leading symbols like #, all in lower case
 	// Set of spaces this room is a part of, from the perspective of this user. This is NOT global room data
 	// as the set of spaces may be different for different users.
+
+	// ResolvedAvatarURL is the avatar that should be displayed to this user to
+	// represent this room. The empty string means that this room has no avatar.
+	// Avatars set in m.room.avatar take precedence; if this is missing and the room is
+	// a DM with one other user joined or invited, we fall back to that user's
+	// avatar (if any) as specified in their membership event in that room.
+	ResolvedAvatarURL string
+
 	Spaces map[string]struct{}
 	// Map of tag to order float.
 	// See https://spec.matrix.org/latest/client-server-api/#room-tagging

--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -109,8 +109,9 @@ func NewInviteData(ctx context.Context, userID, roomID string, inviteState []jso
 				id.IsDM = j.Get("is_direct").Bool()
 			} else if target == j.Get("sender").Str {
 				id.Heroes = append(id.Heroes, internal.Hero{
-					ID:   target,
-					Name: j.Get("content.displayname").Str,
+					ID:     target,
+					Name:   j.Get("content.displayname").Str,
+					Avatar: j.Get("content.avatar_url").Str,
 				})
 			}
 		case "m.room.name":

--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -596,6 +596,7 @@ func (s *ConnState) getInitialRoomData(ctx context.Context, roomSub sync3.RoomSu
 		}
 		rooms[roomID] = sync3.Room{
 			Name:              internal.CalculateRoomName(metadata, 5), // TODO: customisable?
+			AvatarChange:      sync3.NewAvatarChange(internal.CalculateAvatar(metadata)),
 			NotificationCount: int64(userRoomData.NotificationCount),
 			HighlightCount:    int64(userRoomData.HighlightCount),
 			Timeline:          roomToTimeline[roomID],

--- a/sync3/handler/connstate_live.go
+++ b/sync3/handler/connstate_live.go
@@ -297,6 +297,13 @@ func (s *connStateLive) processGlobalUpdates(ctx context.Context, builder *Rooms
 
 		metadata := rup.GlobalRoomMetadata().CopyHeroes()
 		metadata.RemoveHero(s.userID)
+		// TODO: if we change a room from being a DM to not being a DM, we should call
+		// SetRoom and recalculate avatars. To do that we'd need to
+		//  - listen to m.direct global account data events
+		//   - compute the symmetric difference between old and new
+		//   - call SetRooms for each room in the difference.
+		// I'm assuming this happens so rarely that we can ignore this for now. PRs
+		// welcome if you a strong opinion to the contrary.
 		delta = s.lists.SetRoom(sync3.RoomConnMetadata{
 			RoomMetadata:                  *metadata,
 			UserRoomData:                  *rup.UserRoomMetadata(),

--- a/sync3/handler/connstate_live.go
+++ b/sync3/handler/connstate_live.go
@@ -290,8 +290,10 @@ func (s *connStateLive) processGlobalUpdates(ctx context.Context, builder *Rooms
 			}
 		}
 
+		metadata := rup.GlobalRoomMetadata().CopyHeroes()
+		metadata.RemoveHero(s.userID)
 		delta = s.lists.SetRoom(sync3.RoomConnMetadata{
-			RoomMetadata:                  *rup.GlobalRoomMetadata(),
+			RoomMetadata:                  *metadata,
 			UserRoomData:                  *rup.UserRoomMetadata(),
 			LastInterestedEventTimestamps: bumpTimestampInList,
 		})

--- a/sync3/handler/connstate_live.go
+++ b/sync3/handler/connstate_live.go
@@ -218,6 +218,11 @@ func (s *connStateLive) processLiveUpdate(ctx context.Context, up caches.Update,
 				metadata.RemoveHero(s.userID)
 				thisRoom.Name = internal.CalculateRoomName(metadata, 5) // TODO: customisable?
 			}
+			if delta.RoomAvatarChanged {
+				metadata := roomUpdate.GlobalRoomMetadata()
+				metadata.RemoveHero(s.userID)
+				thisRoom.AvatarChange = sync3.NewAvatarChange(internal.CalculateAvatar(metadata))
+			}
 			if delta.InviteCountChanged {
 				thisRoom.InvitedCount = &roomUpdate.GlobalRoomMetadata().InviteCount
 			}

--- a/sync3/lists.go
+++ b/sync3/lists.go
@@ -33,6 +33,7 @@ type RoomListDelta struct {
 
 type RoomDelta struct {
 	RoomNameChanged          bool
+	RoomAvatarChanged        bool
 	JoinCountChanged         bool
 	InviteCountChanged       bool
 	NotificationCountChanged bool
@@ -73,6 +74,10 @@ func (s *InternalRequestLists) SetRoom(r RoomConnMetadata) (delta RoomDelta) {
 				strings.Trim(internal.CalculateRoomName(&r.RoomMetadata, 5), "#!():_@"),
 			)
 		}
+		delta.RoomAvatarChanged = !existing.SameRoomAvatar(&r.RoomMetadata)
+		if delta.RoomAvatarChanged {
+			r.ResolvedAvatarURL = internal.CalculateAvatar(&r.RoomMetadata)
+		}
 
 		// Interpret the timestamp map on r as the changes we should apply atop the
 		// existing timestamps.
@@ -97,6 +102,7 @@ func (s *InternalRequestLists) SetRoom(r RoomConnMetadata) (delta RoomDelta) {
 		r.CanonicalisedName = strings.ToLower(
 			strings.Trim(internal.CalculateRoomName(&r.RoomMetadata, 5), "#!():_@"),
 		)
+		r.ResolvedAvatarURL = internal.CalculateAvatar(&r.RoomMetadata)
 		// We'll automatically use the LastInterestedEventTimestamps provided by the
 		// caller, so that recency sorts work.
 	}

--- a/sync3/lists.go
+++ b/sync3/lists.go
@@ -73,6 +73,16 @@ func (s *InternalRequestLists) SetRoom(r RoomConnMetadata) (delta RoomDelta) {
 			r.CanonicalisedName = strings.ToLower(
 				strings.Trim(internal.CalculateRoomName(&r.RoomMetadata, 5), "#!():_@"),
 			)
+		} else {
+			// XXX: during TestConnectionTimeoutNotReset there is some situation where
+			//      r.CanonicalisedName is the empty string. Looking at the SetRoom
+			//      call in connstate_live.go, this is because the UserRoomMetadata on
+			//      the RoomUpdate has an empty CanonicalisedName. Either
+			//        a) that is expected, in which case we should _always_ write to
+			//           r.CanonicalisedName here; or
+			//        b) that is not expected, in which case... erm, I don't know what
+			//           to conclude.
+			r.CanonicalisedName = existing.CanonicalisedName
 		}
 		delta.RoomAvatarChanged = !existing.SameRoomAvatar(&r.RoomMetadata)
 		if delta.RoomAvatarChanged {

--- a/sync3/room.go
+++ b/sync3/room.go
@@ -10,6 +10,7 @@ import (
 
 type Room struct {
 	Name              string            `json:"name,omitempty"`
+	AvatarChange      AvatarChange      `json:"avatar,omitempty"`
 	RequiredState     []json.RawMessage `json:"required_state,omitempty"`
 	Timeline          []json.RawMessage `json:"timeline,omitempty"`
 	InviteState       []json.RawMessage `json:"invite_state,omitempty"`

--- a/sync3/room_test.go
+++ b/sync3/room_test.go
@@ -1,0 +1,74 @@
+package sync3
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/tidwall/gjson"
+	"reflect"
+	"testing"
+)
+
+func TestAvatarChangeMarshalling(t *testing.T) {
+	var url = "mxc://..."
+	testCases := []struct {
+		Name         string
+		AvatarChange AvatarChange
+		Check        func(avatar gjson.Result) error
+	}{
+		{
+			Name:         "Avatar exists",
+			AvatarChange: NewAvatarChange(url),
+			Check: func(avatar gjson.Result) error {
+				if !(avatar.Exists() && avatar.Type == gjson.String && avatar.Str == url) {
+					return fmt.Errorf("unexpected marshalled avatar: got %#v want %s", avatar, url)
+				}
+				return nil
+			},
+		},
+		{
+			Name:         "Avatar doesn't exist",
+			AvatarChange: DeletedAvatar,
+			Check: func(avatar gjson.Result) error {
+				if !(avatar.Exists() && avatar.Type == gjson.Null) {
+					return fmt.Errorf("unexpected marshalled Avatar: got %#v want null", avatar)
+				}
+				return nil
+			},
+		},
+		{
+			Name:         "Avatar unchanged",
+			AvatarChange: UnchangedAvatar,
+			Check: func(avatar gjson.Result) error {
+				if avatar.Exists() {
+					return fmt.Errorf("unexpected marshalled Avatar: got %#v want omitted", avatar)
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			room := Room{AvatarChange: tc.AvatarChange}
+			marshalled, err := json.Marshal(room)
+			t.Logf("Marshalled to %s", string(marshalled))
+			if err != nil {
+				t.Fatal(err)
+			}
+			avatar := gjson.GetBytes(marshalled, "avatar")
+			if err = tc.Check(avatar); err != nil {
+				t.Fatal(err)
+			}
+
+			var unmarshalled Room
+			err = json.Unmarshal(marshalled, &unmarshalled)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("Unmarshalled to %#v", unmarshalled.AvatarChange)
+			if !reflect.DeepEqual(unmarshalled, room) {
+				t.Fatalf("Unmarshalled struct is different from original")
+			}
+		})
+	}
+}

--- a/testutils/m/match.go
+++ b/testutils/m/match.go
@@ -686,13 +686,16 @@ func MatchLists(matchers map[string][]ListMatcher) RespMatcher {
 	}
 }
 
+const AnsiRedForeground = "\x1b[31m"
+const AnsiResetForeground = "\x1b[39m"
+
 func MatchResponse(t *testing.T, res *sync3.Response, matchers ...RespMatcher) {
 	t.Helper()
 	for _, m := range matchers {
 		err := m(res)
 		if err != nil {
-			b, _ := json.Marshal(res)
-			t.Errorf("MatchResponse: %s\n%+v", err, string(b))
+			b, _ := json.MarshalIndent(res, "", "    ")
+			t.Errorf("%vMatchResponse: %s\n%s%v", AnsiRedForeground, err, string(b), AnsiResetForeground)
 		}
 	}
 }

--- a/testutils/m/match.go
+++ b/testutils/m/match.go
@@ -644,6 +644,15 @@ func LogResponse(t *testing.T) RespMatcher {
 	}
 }
 
+// LogRooms is like LogResponse, but only logs the rooms section of the response.
+func LogRooms(t *testing.T) RespMatcher {
+	return func(res *sync3.Response) error {
+		dump, _ := json.MarshalIndent(res.Rooms, "", "    ")
+		t.Logf("Response rooms were: %s", dump)
+		return nil
+	}
+}
+
 func CheckList(listKey string, res sync3.ResponseList, matchers ...ListMatcher) error {
 	for _, m := range matchers {
 		if err := m(res); err != nil {

--- a/testutils/m/match.go
+++ b/testutils/m/match.go
@@ -39,6 +39,39 @@ func MatchRoomName(name string) RoomMatcher {
 	}
 }
 
+// MatchRoomAvatar builds a RoomMatcher which checks that the given room response has
+// set the room's avatar to the given value.
+func MatchRoomAvatar(wantAvatar string) RoomMatcher {
+	return func(r sync3.Room) error {
+		if string(r.AvatarChange) != wantAvatar {
+			return fmt.Errorf("MatchRoomAvatar: got \"%s\" want \"%s\"", r.AvatarChange, wantAvatar)
+		}
+		return nil
+	}
+}
+
+// MatchRoomUnsetAvatar builds a RoomMatcher which checks that the given room has no
+// avatar, or has had its avatar deleted.
+func MatchRoomUnsetAvatar() RoomMatcher {
+	return func(r sync3.Room) error {
+		if r.AvatarChange != sync3.DeletedAvatar {
+			return fmt.Errorf("MatchRoomAvatar: got \"%s\" want \"%s\"", r.AvatarChange, sync3.DeletedAvatar)
+		}
+		return nil
+	}
+}
+
+// MatchRoomUnchangedAvatar builds a RoomMatcher which checks that the given room has no
+// change to its avatar, or has had its avatar deleted.
+func MatchRoomUnchangedAvatar() RoomMatcher {
+	return func(r sync3.Room) error {
+		if r.AvatarChange != sync3.UnchangedAvatar {
+			return fmt.Errorf("MatchRoomAvatar: got \"%s\" want \"%s\"", r.AvatarChange, sync3.UnchangedAvatar)
+		}
+		return nil
+	}
+}
+
 func MatchJoinCount(count int) RoomMatcher {
 	return func(r sync3.Room) error {
 		if r.JoinedCount != count {

--- a/testutils/m/match.go
+++ b/testutils/m/match.go
@@ -222,11 +222,11 @@ func MatchRoomSubscription(roomID string, matchers ...RoomMatcher) RespMatcher {
 	return func(res *sync3.Response) error {
 		room, ok := res.Rooms[roomID]
 		if !ok {
-			return fmt.Errorf("MatchRoomSubscription: want sub for %s but it was missing", roomID)
+			return fmt.Errorf("MatchRoomSubscription[%s]: want sub but it was missing", roomID)
 		}
 		for _, m := range matchers {
 			if err := m(room); err != nil {
-				return fmt.Errorf("MatchRoomSubscription: %s", err)
+				return fmt.Errorf("MatchRoomSubscription[%s]: %s", roomID, err)
 			}
 		}
 		return nil


### PR DESCRIPTION
This corresponds to the MSC change https://github.com/matrix-org/matrix-spec-proposals/pull/3575/commits/1d38101b626249ca732db54f4179b701de883a1f..912621b4d8c5bf4bc7f695acb590c055795c497f.

Supersedes #203.
Closes #166.

Includes opinionated changes to the test helpers.

Sticky bits:

- the machinery of which avatar to use and when
- having a type that json-serialises to an optional nullable string is awkward
- avoid the copy-slices-with-same-backing array problem
- a test case failure I can fix but cannot understand

I have chosen to deliberately ignore changes to the DM flag. In fact, I don't think CalculateAvatar even _reads_ the DM flag. I expect this will be good enough for a first pass.

**Strongly recommend reviewing commit-by-commit.**