### PR TITLE
Bump docker-setup-qemu-action to v2

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to GitHub Containers


### PR DESCRIPTION
Looking at https://github.com/docker/setup-qemu-action/releases I can only see the node 16 runtime as a breaking change. Fixes #170, hopefully.

