### PR TITLE
Fix Nginx-example regex case-sensitivity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,14 @@ In both cases, the path `https://example.com/.well-known/matrix/client` must ret
 #### Same hostname
 The following nginx configuration can be used to pass the required endpoints to the sync proxy, running on local port 8009 (so as to not conflict with Synapse):
 ```nginx
-location ~* ^/(client/|_matrix/client/unstable/org.matrix.msc3575/sync) {
+location ~ ^/(client/|_matrix/client/unstable/org.matrix.msc3575/sync) {
     proxy_pass http://localhost:8009;
     proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Host $host;
 }
 
-location ~* ^(\/_matrix|\/_synapse\/client) {
+location ~ ^(\/_matrix|\/_synapse\/client) {
     proxy_pass http://localhost:8008;
     proxy_set_header X-Forwarded-For $remote_addr;
     proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
Matrix endpoints are specified to be case sensitive always, fix the Nginx-example to be case-sensitive instead case-insensitive

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

Signed-off-by: Sami Olmari <sami@olmari.fi>