### PR TITLE
Implement message ignoring for new conns

### DIFF
--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -326,6 +326,7 @@ func (c *UserCache) LazyLoadTimelines(ctx context.Context, loadPos int64, roomID
 			urd = NewUserRoomData()
 		}
 		if latestEvents != nil {
+			latestEvents.DiscardIgnoredMessages(c.ShouldIgnore)
 			urd.RequestedLatestEvents = *latestEvents
 		}
 		result[requestedRoomID] = urd

--- a/tests-integration/ignored_users_test.go
+++ b/tests-integration/ignored_users_test.go
@@ -161,8 +161,10 @@ func TestIgnoredUsersDuringLiveUpdate(t *testing.T) {
 			},
 		},
 	})
-	t.Log("Alice sees her message.")
-	m.MatchResponse(t, aliceRes, m.MatchRoomSubscription(roomID, m.MatchRoomTimelineMostRecent(1, []json.RawMessage{aliceMsg2})))
+	t.Log("Alice sees her join, her messages and nigel's state in the timeline.")
+	m.MatchResponse(t, aliceRes, m.MatchRoomSubscription(roomID, m.MatchRoomTimeline([]json.RawMessage{
+		aliceJoin, aliceMsg, nigelState, aliceMsg2,
+	})))
 
 	t.Log("Bob's poller sees Nigel and Alice send a message.")
 	nigelMsg2 := testutils.NewMessageEvent(t, nigel, "naughty nigel 3")


### PR DESCRIPTION
I've cut corners here and not tested ignored messages in lists (rather than room subscriptions) when you load up a new conn. (AFAICS they both use LazyLoadTimelines to actually get the timeline).

More of #231. Follows #238. 