### PR TITLE
Fix DB migration by pulling out everything from the DB first

### DIFF
--- a/state/device_data_table_test.go
+++ b/state/device_data_table_test.go
@@ -29,7 +29,7 @@ func TestDeviceDataTableSwaps(t *testing.T) {
 	defer close()
 	table := NewDeviceDataTable(db)
 	userID := "@bob"
-	deviceID := "BOB"
+	deviceID := "💣"
 
 	// test accumulating deltas
 	deltas := []internal.DeviceData{
@@ -60,7 +60,7 @@ func TestDeviceDataTableSwaps(t *testing.T) {
 			UserID:   userID,
 			DeviceID: deviceID,
 			DeviceLists: internal.DeviceLists{
-				New: internal.ToDeviceListChangesMap([]string{"bob"}, nil),
+				New: internal.ToDeviceListChangesMap([]string{"💣"}, nil),
 			},
 		},
 	}
@@ -77,7 +77,7 @@ func TestDeviceDataTableSwaps(t *testing.T) {
 		},
 		FallbackKeyTypes: []string{"foobar"},
 		DeviceLists: internal.DeviceLists{
-			New:  internal.ToDeviceListChangesMap([]string{"alice", "bob"}, nil),
+			New:  internal.ToDeviceListChangesMap([]string{"alice", "💣"}, nil),
 			Sent: map[string]int{},
 		},
 	}
@@ -98,7 +98,7 @@ func TestDeviceDataTableSwaps(t *testing.T) {
 	// changed bits were reset when we swapped
 	want2 := want
 	want2.DeviceLists = internal.DeviceLists{
-		Sent: internal.ToDeviceListChangesMap([]string{"alice", "bob"}, nil),
+		Sent: internal.ToDeviceListChangesMap([]string{"alice", "💣"}, nil),
 		New:  map[string]int{},
 	}
 	want2.ChangedBits = 0
@@ -142,7 +142,7 @@ func TestDeviceDataTableSwaps(t *testing.T) {
 		UserID:   userID,
 		DeviceID: deviceID,
 		DeviceLists: internal.DeviceLists{
-			New: internal.ToDeviceListChangesMap([]string{"bob"}, []string{"charlie"}),
+			New: internal.ToDeviceListChangesMap([]string{"💣"}, []string{"charlie"}),
 		},
 	})
 	assertNoError(t, err)
@@ -151,8 +151,8 @@ func TestDeviceDataTableSwaps(t *testing.T) {
 
 	want4 := want
 	want4.DeviceLists = internal.DeviceLists{
-		Sent: internal.ToDeviceListChangesMap([]string{"alice", "bob"}, nil),
-		New:  internal.ToDeviceListChangesMap([]string{"bob"}, []string{"charlie"}),
+		Sent: internal.ToDeviceListChangesMap([]string{"alice", "💣"}, nil),
+		New:  internal.ToDeviceListChangesMap([]string{"💣"}, []string{"charlie"}),
 	}
 	// Without swapping, we expect Alice and Bob in Sent, and Bob and Charlie in New
 	got, err = table.Select(userID, deviceID, false)
@@ -173,8 +173,8 @@ func TestDeviceDataTableSwaps(t *testing.T) {
 	assertNoError(t, err)
 	want5 := want4
 	want5.DeviceLists = internal.DeviceLists{
-		Sent: internal.ToDeviceListChangesMap([]string{"alice", "bob"}, nil),
-		New:  internal.ToDeviceListChangesMap([]string{"bob"}, []string{"charlie", "dave"}),
+		Sent: internal.ToDeviceListChangesMap([]string{"alice", "💣"}, nil),
+		New:  internal.ToDeviceListChangesMap([]string{"💣"}, []string{"charlie", "dave"}),
 	}
 	assertDeviceData(t, *got, want5)
 
@@ -183,7 +183,7 @@ func TestDeviceDataTableSwaps(t *testing.T) {
 	assertNoError(t, err)
 	want5 = want4
 	want5.DeviceLists = internal.DeviceLists{
-		Sent: internal.ToDeviceListChangesMap([]string{"bob"}, []string{"charlie", "dave"}),
+		Sent: internal.ToDeviceListChangesMap([]string{"💣"}, []string{"charlie", "dave"}),
 		New:  map[string]int{},
 	}
 	assertDeviceData(t, *got, want5)

--- a/state/device_data_table_test.go
+++ b/state/device_data_table_test.go
@@ -29,7 +29,7 @@ func TestDeviceDataTableSwaps(t *testing.T) {
 	defer close()
 	table := NewDeviceDataTable(db)
 	userID := "@bob"
-	deviceID := "💣"
+	deviceID := "BOB"
 
 	// test accumulating deltas
 	deltas := []internal.DeviceData{

--- a/state/migrations/20230802121023_device_data_jsonb.go
+++ b/state/migrations/20230802121023_device_data_jsonb.go
@@ -39,6 +39,7 @@ func upJSONB(ctx context.Context, tx *sql.Tx) error {
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
 
 	// abusing PollerID here
 	var deviceData sync2.PollerID
@@ -58,6 +59,10 @@ func upJSONB(ctx context.Context, tx *sql.Tx) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if rows.Err() != nil {
+		return rows.Err()
 	}
 
 	_, err = tx.ExecContext(ctx, "ALTER TABLE IF EXISTS syncv3_device_data DROP COLUMN IF EXISTS data;")

--- a/state/migrations/20230802121023_device_data_jsonb.go
+++ b/state/migrations/20230802121023_device_data_jsonb.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/matrix-org/sliding-sync/sync2"
 	"github.com/pressly/goose/v3"
 )
 
@@ -33,10 +34,32 @@ func upJSONB(ctx context.Context, tx *sql.Tx) error {
 	if err != nil {
 		return err
 	}
-	_, err = tx.ExecContext(ctx, "UPDATE syncv3_device_data SET dataj = encode(data, 'escape')::JSONB;")
+
+	rows, err := tx.Query("SELECT user_id, device_id, data FROM syncv3_device_data")
 	if err != nil {
 		return err
 	}
+
+	// abusing PollerID here
+	var deviceData sync2.PollerID
+	var data []byte
+
+	// map from PollerID -> deviceData
+	deviceDatas := make(map[sync2.PollerID][]byte)
+	for rows.Next() {
+		if err = rows.Scan(&deviceData.UserID, &deviceData.DeviceID, &data); err != nil {
+			return err
+		}
+		deviceDatas[deviceData] = data
+	}
+
+	for dd, d := range deviceDatas {
+		_, err = tx.ExecContext(ctx, "UPDATE syncv3_device_data SET dataj = $1 WHERE user_id = $2 AND device_id = $3;", d, dd.UserID, dd.DeviceID)
+		if err != nil {
+			return err
+		}
+	}
+
 	_, err = tx.ExecContext(ctx, "ALTER TABLE IF EXISTS syncv3_device_data DROP COLUMN IF EXISTS data;")
 	if err != nil {
 		return err

--- a/state/migrations/20230802121023_device_data_jsonb_test.go
+++ b/state/migrations/20230802121023_device_data_jsonb_test.go
@@ -1,0 +1,86 @@
+package migrations
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq"
+	"github.com/matrix-org/sliding-sync/internal"
+	"github.com/matrix-org/sliding-sync/testutils"
+)
+
+var postgresConnectionString = "user=xxxxx dbname=syncv3_test sslmode=disable"
+
+func TestMain(m *testing.M) {
+	postgresConnectionString = testutils.PrepareDBConnectionString()
+	exitCode := m.Run()
+	os.Exit(exitCode)
+}
+
+func connectToDB(t *testing.T) (*sqlx.DB, func()) {
+	db, err := sqlx.Open("postgres", postgresConnectionString)
+	if err != nil {
+		t.Fatalf("failed to open SQL db: %s", err)
+	}
+	return db, func() {
+		db.Close()
+	}
+}
+
+func TestJSONBMigration(t *testing.T) {
+	ctx := context.Background()
+	db, close := connectToDB(t)
+	defer close()
+
+	// Create the table in the old format (data = BYTEA instead of JSONB)
+	_, err := db.Exec(`CREATE TABLE syncv3_device_data (
+		user_id TEXT NOT NULL,
+		device_id TEXT NOT NULL,
+		data BYTEA NOT NULL,
+		UNIQUE(user_id, device_id)
+	);`)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Commit()
+
+	// insert some "invalid" data
+	dd := internal.DeviceData{
+		DeviceLists: internal.DeviceLists{
+			New:  map[string]int{"@💣:localhost": 1},
+			Sent: map[string]int{},
+		},
+		OTKCounts:        map[string]int{},
+		FallbackKeyTypes: []string{},
+	}
+	data, err := json.Marshal(dd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = tx.ExecContext(ctx, `INSERT INTO syncv3_device_data (user_id, device_id, data) VALUES ($1, $2, $3)`, "bob", "bobDev", data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// validate that invalid data can be migrated upwards
+	err = upJSONB(ctx, tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// and downgrade again
+	err = downJSONB(ctx, tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Given the discussed issue from yesterday, this is merely a workaround for the migration, as I couldn't find a viable way to do this in SQL directly.