### PR TITLE
Ignore more stray timelines in Accumulate

### DIFF
--- a/state/accumulator.go
+++ b/state/accumulator.go
@@ -335,7 +335,7 @@ func (a *Accumulator) Accumulate(txn *sqlx.Tx, userID, roomID string, prevBatch 
 			// All okay, continue on.
 		} else {
 			// Bail out and complain loudly.
-			err = fmt.Errorf("accumulator: skipping processing of timeline, as no snapshot exists")
+			const msg = "Accumulator: skipping processing of timeline, as no snapshot exists"
 			logger.Warn().
 				Str("event_id", dedupedEvents[0].ID).
 				Str("event_type", dedupedEvents[0].Type).
@@ -343,7 +343,7 @@ func (a *Accumulator) Accumulate(txn *sqlx.Tx, userID, roomID string, prevBatch 
 				Str("room_id", roomID).
 				Str("user_id", userID).
 				Int("len_timeline", len(dedupedEvents)).
-				Msg(err.Error())
+				Msg(msg)
 			sentry.WithScope(func(scope *sentry.Scope) {
 				scope.SetUser(sentry.User{ID: userID})
 				scope.SetContext(internal.SentryCtxKey, map[string]interface{}{
@@ -353,9 +353,9 @@ func (a *Accumulator) Accumulate(txn *sqlx.Tx, userID, roomID string, prevBatch 
 					"room_id":         roomID,
 					"len_timeline":    len(dedupedEvents),
 				})
-				sentry.CaptureException(err)
+				sentry.CaptureMessage(msg)
 			})
-			return 0, nil, err
+			return 0, nil, nil
 		}
 	}
 

--- a/tests-integration/filters_test.go
+++ b/tests-integration/filters_test.go
@@ -154,6 +154,7 @@ func TestFiltersInvite(t *testing.T) {
 	rig := NewTestRig(t)
 	defer rig.Finish()
 	roomID := "!a:localhost"
+	t.Log("Alice is invited to a room.")
 	rig.SetupV2RoomsForUser(t, alice, NoFlush, map[string]RoomDescriptor{
 		roomID: {
 			MembershipOfSyncer: "invite",
@@ -161,7 +162,7 @@ func TestFiltersInvite(t *testing.T) {
 	})
 	aliceToken := rig.Token(alice)
 
-	// make sure the is_invite filter works
+	t.Log("Alice sliding syncs, requesting two separate lists: invites and joined rooms.")
 	res := rig.V3.mustDoV3Request(t, aliceToken, sync3.Request{
 		Lists: map[string]sync3.RequestList{
 			"inv": {
@@ -182,6 +183,7 @@ func TestFiltersInvite(t *testing.T) {
 			},
 		},
 	})
+	t.Log("Alice should see the room appear in the invites list, and nothing in the joined rooms list.")
 	m.MatchResponse(t, res, m.MatchLists(
 		map[string][]m.ListMatcher{
 			"inv": {
@@ -196,7 +198,7 @@ func TestFiltersInvite(t *testing.T) {
 		},
 	))
 
-	// Accept the invite
+	t.Log("Alice accepts the invite.")
 	rig.JoinRoom(t, alice, roomID)
 
 	// now the room should move from one room to another

--- a/tests-integration/filters_test.go
+++ b/tests-integration/filters_test.go
@@ -3,6 +3,7 @@ package syncv3
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/matrix-org/sliding-sync/sync2"
 	"github.com/matrix-org/sliding-sync/sync3"
@@ -199,7 +200,20 @@ func TestFiltersInvite(t *testing.T) {
 	))
 
 	t.Log("Alice accepts the invite.")
-	rig.JoinRoom(t, alice, roomID)
+	rig.V2.queueResponse(alice, sync2.SyncResponse{
+		Rooms: sync2.SyncRoomsResponse{
+			Join: map[string]sync2.SyncV2JoinResponse{
+				roomID: {
+					State: sync2.EventsResponse{
+						Events: createRoomState(t, "@creator:other", time.Now()),
+					},
+					Timeline: sync2.TimelineResponse{
+						Events: []json.RawMessage{testutils.NewJoinEvent(t, alice)},
+					},
+				},
+			},
+		},
+	})
 
 	// now the room should move from one room to another
 	res = rig.V3.mustDoV3RequestWithPos(t, aliceToken, res.Pos, sync3.Request{


### PR DESCRIPTION
Described in https://github.com/matrix-org/sliding-sync/issues/211#issuecomment-1682728834.

This is essentially cherry picked from #248, in particular the commit
    https://github.com/matrix-org/sliding-sync/pull/248/commits/8c7046e96b4efec5930e02cb9d8daefe65d3d7e7

This should prevent creating new snapshots that don't reflect the state of the room. We'll need a followup task to clean up bad snapshots.