### PR TITLE
Improve performace when getting room state after event position

### DIFF
--- a/sync3/dispatcher.go
+++ b/sync3/dispatcher.go
@@ -47,6 +47,10 @@ func (d *Dispatcher) IsUserJoined(userID, roomID string) bool {
 	return d.jrt.IsUserJoined(userID, roomID)
 }
 
+func (d *Dispatcher) IsUserInvited(userID, roomID string) bool {
+	return d.jrt.IsUserInvited(userID, roomID)
+}
+
 // Load joined members into the dispatcher.
 // MUST BE CALLED BEFORE V2 POLL LOOPS START.
 func (d *Dispatcher) Startup(roomToJoinedUsers map[string][]string) error {

--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -590,10 +590,20 @@ func (s *ConnState) getInitialRoomData(ctx context.Context, roomSub sync3.RoomSu
 	}
 	roomToTimeline = s.userCache.AnnotateWithTransactionIDs(ctx, s.userID, s.deviceID, roomToTimeline)
 	rsm := roomSub.RequiredStateMap(s.userID)
+
+	// The room state is only needed for rooms we are actually joined to, so we don't need to fetch it
+	// for rooms we are invited to.
+	joinedRooms := make([]string, 0, len(roomIDs))
+	for _, roomID := range roomIDs {
+		if s.joinChecker.IsUserJoined(s.userID, roomID) {
+			joinedRooms = append(joinedRooms, roomID)
+		}
+	}
+
 	// by reusing the same global load position anchor here, we can be sure that the state returned here
 	// matches the timeline we loaded earlier - the race conditions happen around pubsub updates and not
 	// the events table itself, so whatever position is picked based on this anchor is immutable.
-	roomIDToState := s.globalCache.LoadRoomState(ctx, roomIDs, s.anchorLoadPosition, rsm, roomToUsersInTimeline)
+	roomIDToState := s.globalCache.LoadRoomState(ctx, joinedRooms, s.anchorLoadPosition, rsm, roomToUsersInTimeline)
 	if roomIDToState == nil { // e.g no required_state
 		roomIDToState = make(map[string][]json.RawMessage)
 	}

--- a/sync3/handler/connstate_test.go
+++ b/sync3/handler/connstate_test.go
@@ -31,6 +31,10 @@ func (t *NopJoinTracker) IsUserJoined(userID, roomID string) bool {
 	return true
 }
 
+func (t *NopJoinTracker) IsUserInvited(userID, roomID string) bool {
+	return true
+}
+
 type NopTransactionFetcher struct{}
 
 func (t *NopTransactionFetcher) TransactionIDForEvents(userID, deviceID string, eventIDs []string) (eventIDToTxnID map[string]string) {

--- a/sync3/tracker.go
+++ b/sync3/tracker.go
@@ -179,6 +179,18 @@ func (t *JoinedRoomsTracker) UsersInvitedToRoom(userIDs []string, roomID string)
 	t.roomIDToInvitedUsers[roomID] = users
 }
 
+func (t *JoinedRoomsTracker) IsUserInvited(userID, roomID string) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	users := t.roomIDToInvitedUsers[roomID]
+	for u := range users {
+		if u == userID {
+			return true
+		}
+	}
+	return false
+}
+
 func (t *JoinedRoomsTracker) NumInvitedUsersForRoom(roomID string) int {
 	t.mu.RLock()
 	defer t.mu.RUnlock()

--- a/sync3/tracker_test.go
+++ b/sync3/tracker_test.go
@@ -45,8 +45,10 @@ func TestTracker(t *testing.T) {
 
 	jrt.UsersInvitedToRoom([]string{"alice"}, "room4")
 	assertNumEquals(t, jrt.NumInvitedUsersForRoom("room4"), 1)
+	assertBool(t, "expected alice to be invited", jrt.IsUserInvited("alice", "room4"), true)
 	jrt.UserJoinedRoom("alice", "room4")
 	assertNumEquals(t, jrt.NumInvitedUsersForRoom("room4"), 0)
+	assertBool(t, "expected alice to be not invited anymore", jrt.IsUserInvited("alice", "room4"), false)
 	jrt.UserJoinedRoom("alice", "room4") // dupe joins don't bother it
 	assertNumEquals(t, jrt.NumInvitedUsersForRoom("room4"), 0)
 	jrt.UsersInvitedToRoom([]string{"bob"}, "room4")
@@ -55,6 +57,8 @@ func TestTracker(t *testing.T) {
 	assertNumEquals(t, jrt.NumInvitedUsersForRoom("room4"), 1)
 	jrt.UserLeftRoom("bob", "room4")
 	assertNumEquals(t, jrt.NumInvitedUsersForRoom("room4"), 0)
+
+	assertBool(t, "expected unknown user to be not invited", jrt.IsUserInvited("doesnotexist", "room3"), false)
 }
 
 func TestTrackerStartup(t *testing.T) {


### PR DESCRIPTION
Possibly related: https://github.com/matrix-org/sliding-sync/issues/260

As per the comment in code, this reduces the query execution time for a room with 86k membership events from 2.5s to 133ms.