### PR TITLE
Use the userCache to check if the user is invited

### DIFF
--- a/sync3/dispatcher.go
+++ b/sync3/dispatcher.go
@@ -47,10 +47,6 @@ func (d *Dispatcher) IsUserJoined(userID, roomID string) bool {
 	return d.jrt.IsUserJoined(userID, roomID)
 }
 
-func (d *Dispatcher) IsUserInvited(userID, roomID string) bool {
-	return d.jrt.IsUserInvited(userID, roomID)
-}
-
 // Load joined members into the dispatcher.
 // MUST BE CALLED BEFORE V2 POLL LOOPS START.
 func (d *Dispatcher) Startup(roomToJoinedUsers map[string][]string) error {

--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -15,7 +15,6 @@ import (
 
 type JoinChecker interface {
 	IsUserJoined(userID, roomID string) bool
-	IsUserInvited(userID, roomID string) bool
 }
 
 // ConnState tracks all high-level connection state for this connection, like the combined request
@@ -596,7 +595,8 @@ func (s *ConnState) getInitialRoomData(ctx context.Context, roomSub sync3.RoomSu
 	// since we'll be using the invite_state only.
 	loadRoomIDs := make([]string, 0, len(roomIDs))
 	for _, roomID := range roomIDs {
-		if !s.joinChecker.IsUserInvited(s.userID, roomID) {
+		userRoomData, ok := roomIDToUserRoomData[roomID]
+		if !ok || !userRoomData.IsInvite {
 			loadRoomIDs = append(loadRoomIDs, roomID)
 		}
 	}

--- a/sync3/handler/connstate_test.go
+++ b/sync3/handler/connstate_test.go
@@ -31,10 +31,6 @@ func (t *NopJoinTracker) IsUserJoined(userID, roomID string) bool {
 	return true
 }
 
-func (t *NopJoinTracker) IsUserInvited(userID, roomID string) bool {
-	return true
-}
-
 type NopTransactionFetcher struct{}
 
 func (t *NopTransactionFetcher) TransactionIDForEvents(userID, deviceID string, eventIDs []string) (eventIDToTxnID map[string]string) {

--- a/sync3/tracker.go
+++ b/sync3/tracker.go
@@ -179,18 +179,6 @@ func (t *JoinedRoomsTracker) UsersInvitedToRoom(userIDs []string, roomID string)
 	t.roomIDToInvitedUsers[roomID] = users
 }
 
-func (t *JoinedRoomsTracker) IsUserInvited(userID, roomID string) bool {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	users := t.roomIDToInvitedUsers[roomID]
-	for u := range users {
-		if u == userID {
-			return true
-		}
-	}
-	return false
-}
-
 func (t *JoinedRoomsTracker) NumInvitedUsersForRoom(roomID string) int {
 	t.mu.RLock()
 	defer t.mu.RUnlock()

--- a/sync3/tracker_test.go
+++ b/sync3/tracker_test.go
@@ -45,10 +45,8 @@ func TestTracker(t *testing.T) {
 
 	jrt.UsersInvitedToRoom([]string{"alice"}, "room4")
 	assertNumEquals(t, jrt.NumInvitedUsersForRoom("room4"), 1)
-	assertBool(t, "expected alice to be invited", jrt.IsUserInvited("alice", "room4"), true)
 	jrt.UserJoinedRoom("alice", "room4")
 	assertNumEquals(t, jrt.NumInvitedUsersForRoom("room4"), 0)
-	assertBool(t, "expected alice to be not invited anymore", jrt.IsUserInvited("alice", "room4"), false)
 	jrt.UserJoinedRoom("alice", "room4") // dupe joins don't bother it
 	assertNumEquals(t, jrt.NumInvitedUsersForRoom("room4"), 0)
 	jrt.UsersInvitedToRoom([]string{"bob"}, "room4")
@@ -56,9 +54,6 @@ func TestTracker(t *testing.T) {
 	jrt.UsersInvitedToRoom([]string{"bob"}, "room4") // dupe invites don't bother it
 	assertNumEquals(t, jrt.NumInvitedUsersForRoom("room4"), 1)
 	jrt.UserLeftRoom("bob", "room4")
-	assertNumEquals(t, jrt.NumInvitedUsersForRoom("room4"), 0)
-
-	assertBool(t, "expected unknown user to be not invited", jrt.IsUserInvited("doesnotexist", "room3"), false)
 }
 
 func TestTrackerStartup(t *testing.T) {


### PR DESCRIPTION
Partly reverts https://github.com/matrix-org/sliding-sync/pull/264.
The problem with the previous "solution" was, that the `roomIDToInvitedUsers` a) doesn't seem to be populated on start up and b) isn't set when creating a new cache - this both results in `IsUserInvited` being false, even though it should be true and thus resulting in the "bad" query to be executed.