### PR TITLE
Log setup and processing times for requests

### DIFF
--- a/internal/context.go
+++ b/internal/context.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/getsentry/sentry-go"
 
@@ -25,6 +26,8 @@ type data struct {
 	next                 int64
 	numRooms             int
 	txnID                string
+	setupTime            time.Duration
+	processingTime       time.Duration
 	numToDeviceEvents    int
 	numGlobalAccountData int
 	numChangedDevices    int
@@ -143,4 +146,31 @@ func DecorateLogger(ctx context.Context, l *zerolog.Event) *zerolog.Event {
 	// always log the connection ID so we know when it isn't set
 	l = l.Str("c", da.connID)
 	return l
+}
+
+func SetRequestContextSetupDuration(ctx context.Context, setup time.Duration) {
+	d := ctx.Value(ctxData)
+	if d == nil {
+		return
+	}
+	da := d.(*data)
+	da.setupTime = setup
+}
+
+func SetRequestContextProcessingDuration(ctx context.Context, processing time.Duration) {
+	d := ctx.Value(ctxData)
+	if d == nil {
+		return
+	}
+	da := d.(*data)
+	da.processingTime = processing
+}
+
+func RequestContextDurations(ctx context.Context) (setup time.Duration, processing time.Duration) {
+	d := ctx.Value(ctxData)
+	if d == nil {
+		return 0, 0
+	}
+	da := d.(*data)
+	return da.setupTime, da.processingTime
 }

--- a/v3.go
+++ b/v3.go
@@ -196,7 +196,7 @@ func RunSyncV3Server(h http.Handler, bindAddr, destV2Server, tlsCert, tlsKey str
 				durStr := fmt.Sprintf("%.3f", duration.Seconds())
 				setupDur, processingDur := internal.RequestContextDurations(r.Context())
 				if setupDur != 0 || processingDur != 0 {
-					durStr += fmt.Sprintf("(%.3fs+%.3fp)", setupDur.Seconds(), processingDur.Seconds())
+					durStr += fmt.Sprintf("(%.3f+%.3f)", setupDur.Seconds(), processingDur.Seconds())
 				}
 				entry.Int("status", status).
 					Int("size", size).

--- a/v3.go
+++ b/v3.go
@@ -193,9 +193,14 @@ func RunSyncV3Server(h http.Handler, bindAddr, destV2Server, tlsCert, tlsKey str
 				if !strings.HasSuffix(r.URL.Path, "/sync") {
 					entry.Str("path", r.URL.Path)
 				}
+				durStr := fmt.Sprintf("%.3f", duration.Seconds())
+				setupDur, processingDur := internal.RequestContextDurations(r.Context())
+				if setupDur != 0 || processingDur != 0 {
+					durStr += fmt.Sprintf("(%.3fs+%.3fp)", setupDur.Seconds(), processingDur.Seconds())
+				}
 				entry.Int("status", status).
 					Int("size", size).
-					Dur("duration", duration).
+					Str("duration", durStr).
 					Msg("")
 			}),
 		},


### PR DESCRIPTION
Closes #277.

Today:

```
09:22:04 INF c=room-list dev=DEVICE duration=8598.718051 l=3 p=11 q=12 r=0 size=128 status=200 u=@USER:DOMAIN
```

Proposed:
```
12:08:35 INF b=0/0/2000 c= dev=WYSSJLBWLM duration=0.022(0.000+0.000) p=3 q=4 r=0 size=263 status=200 u=@bob-1693480114-2:synapse
```