### PR TITLE
Logging: show req timings when prometheus is off

### DIFF
--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -688,6 +688,7 @@ func (s *ConnState) getInitialRoomData(ctx context.Context, roomSub sync3.RoomSu
 }
 
 func (s *ConnState) trackSetupDuration(ctx context.Context, dur time.Duration, isInitial bool) {
+	internal.SetRequestContextSetupDuration(ctx, dur)
 	if s.setupHistogramVec == nil {
 		return
 	}
@@ -696,10 +697,10 @@ func (s *ConnState) trackSetupDuration(ctx context.Context, dur time.Duration, i
 		val = "1"
 	}
 	s.setupHistogramVec.WithLabelValues(val).Observe(float64(dur.Seconds()))
-	internal.SetRequestContextSetupDuration(ctx, dur)
 }
 
 func (s *ConnState) trackProcessDuration(ctx context.Context, dur time.Duration, isInitial bool) {
+	internal.SetRequestContextProcessingDuration(ctx, dur)
 	if s.processHistogramVec == nil {
 		return
 	}
@@ -708,7 +709,6 @@ func (s *ConnState) trackProcessDuration(ctx context.Context, dur time.Duration,
 		val = "1"
 	}
 	s.processHistogramVec.WithLabelValues(val).Observe(float64(dur.Seconds()))
-	internal.SetRequestContextProcessingDuration(ctx, dur)
 }
 
 // Called when the connection is torn down


### PR DESCRIPTION
Missed in #278.

