### PR TITLE
Add GitCommit from `debug.ReadBuildInfo`

### DIFF
--- a/cmd/syncv3/main.go
+++ b/cmd/syncv3/main.go
@@ -302,7 +302,7 @@ func init() {
 			if revLen >= gitRevLen {
 				GitCommit = setting.Value[:gitRevLen]
 			} else {
-				GitCommit = setting.Value[:gitRevLen]
+				GitCommit = setting.Value[:revLen]
 			}
 			break
 		}


### PR DESCRIPTION
Similar to https://github.com/matrix-org/dendrite/pull/3147, this adds the git commit sliding-sync was build from.

```bash
$ go build ./cmd/syncv3
$ ./syncv3
Sync v3 [0.99.8] (9c22065)
[....]
```

More of a convenience change, so one doesn't have to remember (from the Dockerfile)
```bash
  GIT_COMMIT=$(git rev-list -1 HEAD) && \
  go build -ldflags "-X main.GitCommit=$GIT_COMMIT" -trimpath -o /out/syncv3 "./cmd/$BINARYNAME"
``` 