### PR TITLE
Return and handle an error bool from V3EnsurePolling/V2InitialSyncComplete

### DIFF
--- a/pubsub/v2.go
+++ b/pubsub/v2.go
@@ -90,6 +90,7 @@ func (*V2InviteRoom) Type() string { return "V2InviteRoom" }
 type V2InitialSyncComplete struct {
 	UserID   string
 	DeviceID string
+	Success  bool
 }
 
 func (*V2InitialSyncComplete) Type() string { return "V2InitialSyncComplete" }

--- a/sync2/handler2/handler.go
+++ b/sync2/handler2/handler.go
@@ -163,7 +163,7 @@ func (h *Handler) StartV2Pollers() {
 				h.v2Pub.Notify(pubsub.ChanV2, &pubsub.V2InitialSyncComplete{
 					UserID:   t.UserID,
 					DeviceID: t.DeviceID,
-					Success:  err != nil,
+					Success:  err == nil,
 				})
 			}
 		}()
@@ -575,7 +575,7 @@ func (h *Handler) EnsurePolling(p *pubsub.V3EnsurePolling) {
 		h.v2Pub.Notify(pubsub.ChanV2, &pubsub.V2InitialSyncComplete{
 			UserID:   p.UserID,
 			DeviceID: p.DeviceID,
-			Success:  err != nil,
+			Success:  err == nil,
 		})
 	}()
 }

--- a/sync2/handler2/handler.go
+++ b/sync2/handler2/handler.go
@@ -160,6 +160,7 @@ func (h *Handler) StartV2Pollers() {
 				h.v2Pub.Notify(pubsub.ChanV2, &pubsub.V2InitialSyncComplete{
 					UserID:   t.UserID,
 					DeviceID: t.DeviceID,
+					Success:  true,
 				})
 			}
 		}()
@@ -568,6 +569,7 @@ func (h *Handler) EnsurePolling(p *pubsub.V3EnsurePolling) {
 		h.v2Pub.Notify(pubsub.ChanV2, &pubsub.V2InitialSyncComplete{
 			UserID:   p.UserID,
 			DeviceID: p.DeviceID,
+			Success:  true,
 		})
 	}()
 }

--- a/sync2/handler2/handler.go
+++ b/sync2/handler2/handler.go
@@ -153,14 +153,17 @@ func (h *Handler) StartV2Pollers() {
 					UserID:   t.UserID,
 					DeviceID: t.DeviceID,
 				}
-				h.pMap.EnsurePolling(
+				_, err = h.pMap.EnsurePolling(
 					pid, t.AccessToken, t.Since, true,
 					logger.With().Str("user_id", t.UserID).Str("device_id", t.DeviceID).Logger(),
 				)
+				if err != nil {
+					logger.Err(err).Str("user_id", t.UserID).Str("device_id", t.DeviceID).Msg("Failed to start poller")
+				}
 				h.v2Pub.Notify(pubsub.ChanV2, &pubsub.V2InitialSyncComplete{
 					UserID:   t.UserID,
 					DeviceID: t.DeviceID,
-					Success:  true,
+					Success:  err != nil,
 				})
 			}
 		}()
@@ -562,14 +565,17 @@ func (h *Handler) EnsurePolling(p *pubsub.V3EnsurePolling) {
 			UserID:   p.UserID,
 			DeviceID: p.DeviceID,
 		}
-		h.pMap.EnsurePolling(
+		_, err = h.pMap.EnsurePolling(
 			pid, accessToken, since, false, log,
 		)
+		if err != nil {
+			log.Err(err).Msg("Failed to start poller")
+		}
 		h.updateMetrics()
 		h.v2Pub.Notify(pubsub.ChanV2, &pubsub.V2InitialSyncComplete{
 			UserID:   p.UserID,
 			DeviceID: p.DeviceID,
-			Success:  true,
+			Success:  err != nil,
 		})
 	}()
 }

--- a/sync2/handler2/handler.go
+++ b/sync2/handler2/handler.go
@@ -546,7 +546,7 @@ func (h *Handler) EnsurePolling(p *pubsub.V3EnsurePolling) {
 	log := logger.With().Str("user_id", p.UserID).Str("device_id", p.DeviceID).Logger()
 	log.Info().Msg("EnsurePolling: new request")
 	defer func() {
-		log.Info().Msg("EnsurePolling: request finished")
+		log.Info().Msg("EnsurePolling: preprocessing done")
 	}()
 	accessToken, since, err := h.v2Store.TokensTable.GetTokenAndSince(p.UserID, p.DeviceID, p.AccessTokenHash)
 	if err != nil {

--- a/sync2/handler2/handler_test.go
+++ b/sync2/handler2/handler_test.go
@@ -52,14 +52,14 @@ func (p *mockPollerMap) ExpirePollers([]sync2.PollerID) int {
 	return 0
 }
 
-func (p *mockPollerMap) EnsurePolling(pid sync2.PollerID, accessToken, v2since string, isStartup bool, logger zerolog.Logger) bool {
+func (p *mockPollerMap) EnsurePolling(pid sync2.PollerID, accessToken, v2since string, isStartup bool, logger zerolog.Logger) (bool, error) {
 	p.calls = append(p.calls, pollInfo{
 		pid:         pid,
 		accessToken: accessToken,
 		v2since:     v2since,
 		isStartup:   isStartup,
 	})
-	return false
+	return false, nil
 }
 
 func (p *mockPollerMap) assertCallExists(t *testing.T, pi pollInfo) {

--- a/sync2/poller.go
+++ b/sync2/poller.go
@@ -295,6 +295,9 @@ func (h *PollerMap) EnsurePolling(pid PollerID, accessToken, v2since string, isS
 	} else {
 		logger.Info().Str("user", poller.userID).Msg("a poller exists for this user; not waiting for this device to do an initial sync")
 	}
+	if poller.terminated.Load() {
+		return false, fmt.Errorf("PollerMap.EnsurePolling: poller terminated after intial sync")
+	}
 	return true, nil
 }
 

--- a/sync2/poller_test.go
+++ b/sync2/poller_test.go
@@ -221,13 +221,16 @@ func TestPollerMap_ExpirePollers(t *testing.T) {
 		{UserID: "delia", DeviceID: "phone", Token: "d_token"},
 	}
 
-	for _, spec := range pollerSpecs {
-		created := pm.EnsurePolling(
+	for i, spec := range pollerSpecs {
+		created, err := pm.EnsurePolling(
 			PollerID{UserID: spec.UserID, DeviceID: spec.DeviceID},
 			spec.Token, "", true, logger,
 		)
+		if err != nil {
+			t.Errorf("EnsurePolling error for poller #%d (%v): %s", i, spec, err)
+		}
 		if !created {
-			t.Errorf("Poller for %v was not newly created", spec)
+			t.Errorf("Poller #%d (%v) was not newly created", i, spec)
 		}
 	}
 
@@ -254,10 +257,13 @@ func TestPollerMap_ExpirePollers(t *testing.T) {
 	}
 
 	for i, spec := range pollerSpecs {
-		created := pm.EnsurePolling(
+		created, err := pm.EnsurePolling(
 			PollerID{UserID: spec.UserID, DeviceID: spec.DeviceID},
 			spec.Token, "", true, logger,
 		)
+		if err != nil {
+			t.Errorf("EnsurePolling error for poller #%d (%v): %s", i, spec, err)
+		}
 		if created != expectDeleted[i] {
 			t.Errorf("Poller #%d (%v): created=%t, expected %t", i, spec, created, expectDeleted[i])
 		}

--- a/sync3/handler/ensure_polling.go
+++ b/sync3/handler/ensure_polling.go
@@ -127,7 +127,8 @@ func (p *EnsurePoller) OnInitialSyncComplete(payload *pubsub.V2InitialSyncComple
 		// e.g from the database
 		log.Trace().Msg("OnInitialSyncComplete: we weren't waiting for this")
 		p.pendingPolls[pid] = pendingInfo{
-			done: true,
+			done:    true,
+			success: payload.Success,
 		}
 		return
 	}
@@ -141,6 +142,7 @@ func (p *EnsurePoller) OnInitialSyncComplete(payload *pubsub.V2InitialSyncComple
 	ch := pending.ch
 	pending.done = true
 	pending.ch = nil
+	pending.success = payload.Success
 	p.pendingPolls[pid] = pending
 	p.calculateNumOutstanding() // decrement total
 	log.Trace().Msg("OnInitialSyncComplete: closing channel")

--- a/sync3/handler/ensure_polling.go
+++ b/sync3/handler/ensure_polling.go
@@ -14,8 +14,10 @@ import (
 // pendingInfo tracks the status of a poller that we are (or previously were) waiting
 // to start.
 type pendingInfo struct {
-	// done is set to true when we confirm that this poller has started polling.
+	// done is set to true when the EnsurePolling request received a response.
 	done bool
+	// success is true when done is true and EnsurePolling succeeded; otherwise false.
+	success bool
 	// ch is a dummy channel which never receives any data. A call to
 	// EnsurePoller.OnInitialSyncComplete will close the channel (unblocking any
 	// EnsurePoller.EnsurePolling calls which are waiting on it) and then set the ch
@@ -57,15 +59,16 @@ func NewEnsurePoller(notifier pubsub.Notifier, enablePrometheus bool) *EnsurePol
 
 // EnsurePolling blocks until the V2InitialSyncComplete response is received for this device. It is
 // the caller's responsibility to call OnInitialSyncComplete when new events arrive.
-func (p *EnsurePoller) EnsurePolling(ctx context.Context, pid sync2.PollerID, tokenHash string) {
+func (p *EnsurePoller) EnsurePolling(ctx context.Context, pid sync2.PollerID, tokenHash string) bool {
 	ctx, region := internal.StartSpan(ctx, "EnsurePolling")
 	defer region.End()
 	p.mu.Lock()
 	// do we need to wait?
 	if p.pendingPolls[pid].done {
 		internal.Logf(ctx, "EnsurePolling", "user %s device %s already done", pid.UserID, pid.DeviceID)
+		success := p.pendingPolls[pid].success
 		p.mu.Unlock()
-		return
+		return success
 	}
 	// have we called EnsurePolling for this user/device before?
 	ch := p.pendingPolls[pid].ch
@@ -79,7 +82,10 @@ func (p *EnsurePoller) EnsurePolling(ctx context.Context, pid sync2.PollerID, to
 		_, r2 := internal.StartSpan(ctx, "waitForExistingChannelClose")
 		<-ch
 		r2.End()
-		return
+		p.mu.Lock()
+		success := p.pendingPolls[pid].success
+		p.mu.Unlock()
+		return success
 	}
 	// Make a channel to wait until we have done an initial sync
 	ch = make(chan struct{})
@@ -101,6 +107,11 @@ func (p *EnsurePoller) EnsurePolling(ctx context.Context, pid sync2.PollerID, to
 	_, r2 := internal.StartSpan(ctx, "waitForNewChannelClose")
 	<-ch
 	r2.End()
+
+	p.mu.Lock()
+	success := p.pendingPolls[pid].success
+	p.mu.Unlock()
+	return success
 }
 
 func (p *EnsurePoller) OnInitialSyncComplete(payload *pubsub.V2InitialSyncComplete) {

--- a/sync3/handler/ensure_polling.go
+++ b/sync3/handler/ensure_polling.go
@@ -58,7 +58,8 @@ func NewEnsurePoller(notifier pubsub.Notifier, enablePrometheus bool) *EnsurePol
 }
 
 // EnsurePolling blocks until the V2InitialSyncComplete response is received for this device. It is
-// the caller's responsibility to call OnInitialSyncComplete when new events arrive.
+// the caller's responsibility to call OnInitialSyncComplete when new events arrive. Returns the Success field from the
+// V2InitialSyncComplete response, which is true iff there is an active poller.
 func (p *EnsurePoller) EnsurePolling(ctx context.Context, pid sync2.PollerID, tokenHash string) bool {
 	ctx, region := internal.StartSpan(ctx, "EnsurePolling")
 	defer region.End()

--- a/tests-integration/poller_test.go
+++ b/tests-integration/poller_test.go
@@ -44,14 +44,14 @@ func TestSecondPollerFiltersToDevice(t *testing.T) {
 	deviceBToken := "DEVICE_B_TOKEN"
 	v2.addAccountWithDeviceID(alice, "B", deviceBToken)
 	seenInitialRequest := false
-	v2.SetCheckRequest(func(userID, token string, req *http.Request) {
-		if userID != alice || token != deviceBToken {
+	v2.SetCheckRequest(func(token string, req *http.Request) {
+		if token != deviceBToken {
 			return
 		}
 		qps := req.URL.Query()
 		since := qps.Get("since")
 		filter := qps.Get("filter")
-		t.Logf("CheckRequest: %v %v since=%v filter=%v", userID, token, since, filter)
+		t.Logf("CheckRequest: %v since=%v filter=%v", token, since, filter)
 		if filter == "" {
 			t.Errorf("expected a filter on all v2 syncs from poller, but got none")
 			return

--- a/tests-integration/poller_test.go
+++ b/tests-integration/poller_test.go
@@ -44,7 +44,7 @@ func TestSecondPollerFiltersToDevice(t *testing.T) {
 	deviceBToken := "DEVICE_B_TOKEN"
 	v2.addAccountWithDeviceID(alice, "B", deviceBToken)
 	seenInitialRequest := false
-	v2.CheckRequest = func(userID, token string, req *http.Request) {
+	v2.SetCheckRequest(func(userID, token string, req *http.Request) {
 		if userID != alice || token != deviceBToken {
 			return
 		}
@@ -88,7 +88,7 @@ func TestSecondPollerFiltersToDevice(t *testing.T) {
 		}
 
 		seenInitialRequest = true
-	}
+	})
 
 	wantMsg := json.RawMessage(`{"type":"f","content":{"f":"b"}}`)
 	v2.queueResponse(deviceBToken, sync2.SyncResponse{

--- a/tests-integration/poller_test.go
+++ b/tests-integration/poller_test.go
@@ -1,6 +1,7 @@
 package syncv3
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"github.com/jmoiron/sqlx"
@@ -455,5 +456,8 @@ func TestPollerExpiryEnsurePollingRace(t *testing.T) {
 		v2.invalidateTokenImmediately(token)
 	})
 
-	v3.mustDoV3Request(t, aliceToken, sync3.Request{})
+	_, _, code := v3.doV3Request(t, context.Background(), aliceToken, "", sync3.Request{})
+	if code == 200 {
+		t.Fatalf("Should have got non 200 http response")
+	}
 }

--- a/tests-integration/poller_test.go
+++ b/tests-integration/poller_test.go
@@ -456,8 +456,9 @@ func TestPollerExpiryEnsurePollingRace(t *testing.T) {
 	})
 
 	t.Log("Alice makes a sliding sync request with a token that's about to expire.")
-	_, _, code := v3.doV3Request(t, context.Background(), aliceToken, "", sync3.Request{})
+	res, _, code := v3.doV3Request(t, context.Background(), aliceToken, "", sync3.Request{})
 	if code == 200 {
-		t.Fatalf("Should have got non 200 http response")
+		pprinted, _ := json.MarshalIndent(res, "", "    ")
+		t.Fatalf("Should have got non 200 http response; got 200 OK\n%s", pprinted)
 	}
 }

--- a/tests-integration/poller_test.go
+++ b/tests-integration/poller_test.go
@@ -446,7 +446,6 @@ func TestPollerExpiryEnsurePollingRace(t *testing.T) {
 	// 3. The old token expires.
 	// 4. The poller tries to call /sync but finds that the token has expired.
 
-	t.Log("Alice makes a sliding sync request.")
 	v2.SetCheckRequest(func(token string, req *http.Request) {
 		if token != aliceToken {
 			t.Fatalf("unexpected poll from %s", token)
@@ -456,6 +455,7 @@ func TestPollerExpiryEnsurePollingRace(t *testing.T) {
 		v2.invalidateTokenImmediately(token)
 	})
 
+	t.Log("Alice makes a sliding sync request with a token that's about to expire.")
 	_, _, code := v3.doV3Request(t, context.Background(), aliceToken, "", sync3.Request{})
 	if code == 200 {
 		t.Fatalf("Should have got non 200 http response")

--- a/tests-integration/poller_test.go
+++ b/tests-integration/poller_test.go
@@ -456,9 +456,8 @@ func TestPollerExpiryEnsurePollingRace(t *testing.T) {
 	})
 
 	t.Log("Alice makes a sliding sync request with a token that's about to expire.")
-	res, _, code := v3.doV3Request(t, context.Background(), aliceToken, "", sync3.Request{})
-	if code == 200 {
-		pprinted, _ := json.MarshalIndent(res, "", "    ")
-		t.Fatalf("Should have got non 200 http response; got 200 OK\n%s", pprinted)
+	_, resBytes, status := v3.doV3Request(t, context.Background(), aliceToken, "", sync3.Request{})
+	if status != http.StatusUnauthorized {
+		t.Fatalf("Should have got 401 http response; got %d\n%s", status, resBytes)
 	}
 }

--- a/tests-integration/poller_test.go
+++ b/tests-integration/poller_test.go
@@ -452,7 +452,7 @@ func TestPollerExpiryEnsurePollingRace(t *testing.T) {
 		}
 		// Expire the token before we process the request.
 		t.Log("Alice's token expires.")
-		v2.invalidateToken(token)
+		v2.invalidateTokenImmediately(token)
 	})
 
 	v3.mustDoV3Request(t, aliceToken, sync3.Request{})

--- a/tests-integration/token_management_test.go
+++ b/tests-integration/token_management_test.go
@@ -54,10 +54,7 @@ func TestSyncWithNewTokenAfterOldExpires(t *testing.T) {
 	)
 
 	t.Log("From this point forward, the poller should not make any initial sync requests.")
-	v2.SetCheckRequest(func(userID, token string, req *http.Request) {
-		if userID != alice {
-			t.Errorf("Got unexpected poll for %s, expected %s only", userID, alice)
-		}
+	v2.SetCheckRequest(func(token string, req *http.Request) {
 		switch token {
 		case aliceToken1: // this is okay; we should return a token expiry response
 		case aliceToken2: // this is also okay; we should provide a proper response
@@ -149,10 +146,7 @@ func TestSyncWithNewTokenBeforeOldExpires(t *testing.T) {
 	)
 
 	t.Log("From this point forward, the poller should not make any initial sync requests.")
-	v2.SetCheckRequest(func(userID, token string, req *http.Request) {
-		if userID != alice {
-			t.Errorf("Got unexpected poll for %s, expected %s only", userID, alice)
-		}
+	v2.SetCheckRequest(func(token string, req *http.Request) {
 		switch token {
 		case aliceToken1: // either is okay
 		case aliceToken2:

--- a/tests-integration/v3_test.go
+++ b/tests-integration/v3_test.go
@@ -54,7 +54,7 @@ type testV2Server struct {
 	// received from pollers, but before the response is generated. This allows us to
 	// confirm that the proxy is polling the homeserver's v2 sync endpoint in the
 	// manner that we expect.
-	checkRequest            func(userID, token string, req *http.Request)
+	checkRequest            func(token string, req *http.Request)
 	mu                      *sync.Mutex
 	tokenToUser             map[string]string
 	tokenToDevice           map[string]string
@@ -65,7 +65,7 @@ type testV2Server struct {
 	timeToWaitForV2Response time.Duration
 }
 
-func (s *testV2Server) SetCheckRequest(fn func(userID, token string, req *http.Request)) {
+func (s *testV2Server) SetCheckRequest(fn func(token string, req *http.Request)) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.checkRequest = fn
@@ -268,7 +268,7 @@ func runTestV2Server(t testutils.TestBenchInterface) *testV2Server {
 		check := server.checkRequest
 		server.mu.Unlock()
 		if check != nil {
-			check(userID, token, req)
+			check(token, req)
 		}
 		resp := server.nextResponse(userID, token)
 		body, err := json.Marshal(resp)

--- a/tests-integration/v3_test.go
+++ b/tests-integration/v3_test.go
@@ -50,11 +50,11 @@ var (
 
 // testV2Server is a fake stand-in for the v2 sync API provided by a homeserver.
 type testV2Server struct {
-	// CheckRequest is an arbitrary function which runs after a request has been
+	// checkRequest is an arbitrary function which runs after a request has been
 	// received from pollers, but before the response is generated. This allows us to
 	// confirm that the proxy is polling the homeserver's v2 sync endpoint in the
 	// manner that we expect.
-	CheckRequest            func(userID, token string, req *http.Request)
+	checkRequest            func(userID, token string, req *http.Request)
 	mu                      *sync.Mutex
 	tokenToUser             map[string]string
 	tokenToDevice           map[string]string
@@ -68,7 +68,7 @@ type testV2Server struct {
 func (s *testV2Server) SetCheckRequest(fn func(userID, token string, req *http.Request)) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.CheckRequest = fn
+	s.checkRequest = fn
 }
 
 // Most tests only use a single device per user. Give them this helper so they don't
@@ -265,7 +265,7 @@ func runTestV2Server(t testutils.TestBenchInterface) *testV2Server {
 			return
 		}
 		server.mu.Lock()
-		check := server.CheckRequest
+		check := server.checkRequest
 		server.mu.Unlock()
 		if check != nil {
 			check(userID, token, req)

--- a/tests-integration/v3_test.go
+++ b/tests-integration/v3_test.go
@@ -97,6 +97,12 @@ func (s *testV2Server) addAccountWithDeviceID(userID, deviceID, token string) {
 	}
 }
 
+// like invalidateToken, but doesn't do any waiting.
+func (s *testV2Server) invalidateTokenImmediately(token string) {
+	delete(s.tokenToUser, token)
+	delete(s.tokenToDevice, token)
+}
+
 // remove the token and wait until the proxy sends a request with this token, then 401 it and return.
 func (s *testV2Server) invalidateToken(token string) {
 	var wg sync.WaitGroup


### PR DESCRIPTION
V2InitialSyncComplete could only represent a success; there was no way to communicate a failure path, leading to the race and symptoms described in #287.