### PR TITLE
Add a bit more tracing, temporary Prometheus metric

### DIFF
--- a/state/storage.go
+++ b/state/storage.go
@@ -88,14 +88,14 @@ func NewStorageWithDB(db *sqlx.DB, addPrometheusMetrics bool) *Storage {
 	}
 
 	if addPrometheusMetrics {
-		acc.snapshotSizeVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		acc.snapshotMemberCountVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: "sliding_sync",
 			Subsystem: "poller",
 			Name:      "snapshot_size",
 			Help:      "Number of membership events in a snapshot",
 			Buckets:   []float64{100.0, 500.0, 1000.0, 5000.0, 10000.0, 20000.0, 50000.0, 100000.0, 150000.0},
 		}, []string{"room_id"})
-		prometheus.MustRegister(acc.snapshotSizeVec)
+		prometheus.MustRegister(acc.snapshotMemberCountVec)
 	}
 
 	return &Storage{
@@ -975,8 +975,8 @@ func (s *Storage) Teardown() {
 	if err != nil {
 		panic("Storage.Teardown: " + err.Error())
 	}
-	if s.Accumulator.snapshotSizeVec != nil {
-		prometheus.Unregister(s.Accumulator.snapshotSizeVec)
+	if s.Accumulator.snapshotMemberCountVec != nil {
+		prometheus.Unregister(s.Accumulator.snapshotMemberCountVec)
 	}
 }
 

--- a/state/storage.go
+++ b/state/storage.go
@@ -975,6 +975,9 @@ func (s *Storage) Teardown() {
 	if err != nil {
 		panic("Storage.Teardown: " + err.Error())
 	}
+	if s.Accumulator.snapshotSizeVec != nil {
+		prometheus.Unregister(s.Accumulator.snapshotSizeVec)
+	}
 }
 
 // circularSlice is a slice which can be appended to which will wraparound at `max`.

--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -308,6 +308,8 @@ func (c *UserCache) OnRegistered(ctx context.Context) error {
 
 // Load timelines from the database. Uses cached UserRoomData for metadata purposes only.
 func (c *UserCache) LazyLoadTimelines(ctx context.Context, loadPos int64, roomIDs []string, maxTimelineEvents int) map[string]UserRoomData {
+	_, span := internal.StartSpan(ctx, "LazyLoadTimelines")
+	defer span.End()
 	if c.LazyRoomDataOverride != nil {
 		return c.LazyRoomDataOverride(loadPos, roomIDs, maxTimelineEvents)
 	}
@@ -408,6 +410,8 @@ func (c *UserCache) Invites() map[string]UserRoomData {
 // which would cause the transaction ID to be missing from the event. Instead, we always look for txn
 // IDs in the v2 poller, and then set them appropriately at request time.
 func (c *UserCache) AnnotateWithTransactionIDs(ctx context.Context, userID string, deviceID string, roomIDToEvents map[string][]json.RawMessage) map[string][]json.RawMessage {
+	_, span := internal.StartSpan(ctx, "AnnotateWithTransactionIDs")
+	defer span.End()
 	var eventIDs []string
 	eventIDToEvent := make(map[string]struct {
 		roomID string

--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -591,6 +591,8 @@ func (s *ConnState) getInitialRoomData(ctx context.Context, roomSub sync3.RoomSu
 	roomToTimeline = s.userCache.AnnotateWithTransactionIDs(ctx, s.userID, s.deviceID, roomToTimeline)
 	rsm := roomSub.RequiredStateMap(s.userID)
 
+	internal.Logf(ctx, "connstate", "getInitialRoomData for %d rooms, RequiredStateMap: %#v", len(roomIDs), rsm)
+
 	// Filter out rooms we are only invited to, as we don't need to fetch the state
 	// since we'll be using the invite_state only.
 	loadRoomIDs := make([]string, 0, len(roomIDs))

--- a/v3.go
+++ b/v3.go
@@ -104,7 +104,7 @@ func Setup(destHomeserver, postgresURI, secret string, opts Opts) (*handler2.Han
 	if opts.DBConnMaxIdleTime > 0 {
 		db.SetConnMaxIdleTime(opts.DBConnMaxIdleTime)
 	}
-	store := state.NewStorageWithDB(db)
+	store := state.NewStorageWithDB(db, opts.AddPrometheusMetrics)
 	storev2 := sync2.NewStoreWithDB(db, secret)
 
 	// Automatically execute migrations


### PR DESCRIPTION
Adds some tracing and logging.
Also adds a temporary histogram to get a feeling how often we're creating a new snapshot. This is to see if a change I have in mind (separate membership table) is a viable solution.