### PR TITLE
bugfix: set unsigned.redacted_because field on redaction

### DIFF
--- a/state/accumulator.go
+++ b/state/accumulator.go
@@ -399,8 +399,8 @@ func (a *Accumulator) Accumulate(txn *sqlx.Tx, userID, roomID string, prevBatch 
 
 	var latestNID int64
 	newEvents := make([]Event, 0, len(eventIDToNID))
-	var redactTheseEventIDs []string
-	for _, ev := range dedupedEvents {
+	redactTheseEventIDs := make(map[string]*Event)
+	for i, ev := range dedupedEvents {
 		nid, ok := eventIDToNID[ev.ID]
 		if ok {
 			ev.NID = int64(nid)
@@ -423,7 +423,7 @@ func (a *Accumulator) Accumulate(txn *sqlx.Tx, userID, roomID string, prevBatch 
 					redactsEventID = parsedEv.Get("content.redacts").Str
 				}
 				if redactsEventID != "" {
-					redactTheseEventIDs = append(redactTheseEventIDs, redactsEventID)
+					redactTheseEventIDs[redactsEventID] = &dedupedEvents[i]
 				}
 			}
 			newEvents = append(newEvents, ev)

--- a/tests-e2e/main_test.go
+++ b/tests-e2e/main_test.go
@@ -77,6 +77,15 @@ func eventsEqual(wantList []Event, gotList []json.RawMessage) error {
 		if want.Sender != "" && want.Sender != got.Sender {
 			return fmt.Errorf("event %d Sender mismatch: got %v want %v", i, got.Sender, want.Sender)
 		}
+		// loop each key on unsigned as unsigned also includes "age" which is unpredictable so cannot DeepEqual
+		if want.Unsigned != nil {
+			for k, v := range want.Unsigned {
+				got := got.Unsigned[k]
+				if !reflect.DeepEqual(got, v) {
+					return fmt.Errorf("event %d Unsigned.%s mismatch: got %v want %v", i, k, got, v)
+				}
+			}
+		}
 	}
 	return nil
 }
@@ -217,4 +226,11 @@ func registerNamedUser(t *testing.T, localpartPrefix string) *CSAPI {
 
 func ptr(s string) *string {
 	return &s
+}
+
+func assertEqual(t *testing.T, msg string, got, want interface{}) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s: got %v want %v", msg, got, want)
+	}
 }


### PR DESCRIPTION
Element X relies on this field being set.

See https://github.com/matrix-org/matrix-spec/issues/1630 for the correctness of this, but regardless, we need to unbreak clients.
