### PR TITLE
Fix duplicate leave events

### DIFF
--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -617,7 +617,6 @@ func (c *UserCache) OnInvite(ctx context.Context, roomID string, inviteStateEven
 
 func (c *UserCache) OnLeftRoom(ctx context.Context, roomID string, leaveEvent json.RawMessage) {
 	urd := c.LoadRoomData(roomID)
-	logger.Trace().Msgf("%#v", urd)
 	wasInvite := urd.IsInvite
 	urd.IsInvite = false
 	urd.HasLeft = true

--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -617,6 +617,8 @@ func (c *UserCache) OnInvite(ctx context.Context, roomID string, inviteStateEven
 
 func (c *UserCache) OnLeftRoom(ctx context.Context, roomID string, leaveEvent json.RawMessage) {
 	urd := c.LoadRoomData(roomID)
+	logger.Trace().Msgf("%#v", urd)
+	wasInvite := urd.IsInvite
 	urd.IsInvite = false
 	urd.HasLeft = true
 	urd.Invite = nil
@@ -627,6 +629,15 @@ func (c *UserCache) OnLeftRoom(ctx context.Context, roomID string, leaveEvent js
 
 	ev := gjson.ParseBytes(leaveEvent)
 	stateKey := ev.Get("state_key").Str
+	sender := ev.Get("sender").Str
+	evType := ev.Get("type").Str
+
+	// If the event in question is a kick, we should AlwaysProcess this to make sure the client
+	// knows about the "leave"
+	isKick := false
+	if evType == "m.room.member" && ev.Get("content.membership").Str == "leave" && stateKey != sender {
+		isKick = true
+	}
 
 	up := &RoomEventUpdate{
 		RoomUpdate: &roomUpdateCache{
@@ -639,14 +650,14 @@ func (c *UserCache) OnLeftRoom(ctx context.Context, roomID string, leaveEvent js
 		EventData: &EventData{
 			Event:     leaveEvent,
 			RoomID:    roomID,
-			EventType: ev.Get("type").Str,
+			EventType: evType,
 			StateKey:  &stateKey,
 			Content:   ev.Get("content"),
 			Timestamp: ev.Get("origin_server_ts").Uint(),
-			Sender:    ev.Get("sender").Str,
-			// if this is an invite rejection we need to make sure we tell the client, and not
+			Sender:    sender,
+			// if this is an invite rejection/a kick we need to make sure we tell the client, and not
 			// skip it because of the lack of a NID (this event may not be in the events table)
-			AlwaysProcess: true,
+			AlwaysProcess: wasInvite || isKick,
 		},
 	}
 	c.emitOnRoomUpdate(ctx, up)

--- a/tests-e2e/membership_transitions_test.go
+++ b/tests-e2e/membership_transitions_test.go
@@ -397,6 +397,63 @@ func TestInviteRejectionTwice(t *testing.T) {
 	})
 }
 
+func TestLeavingRoomReturnsOneEvent(t *testing.T) {
+	alice := registerNewUser(t)
+	bob := registerNewUser(t)
+	roomName := "It's-a-me-invitio"
+	inviteRoomID := alice.CreateRoom(t, map[string]interface{}{"preset": "private_chat", "name": roomName})
+	t.Logf("TestLeavingRoomReturnsOneEvent room %s", inviteRoomID)
+
+	// sync as bob, we see no invites yet.
+	res := bob.SlidingSync(t, sync3.Request{
+		Lists: map[string]sync3.RequestList{
+			"a": {
+				Ranges: sync3.SliceRanges{{0, 20}},
+				Filters: &sync3.RequestFilters{
+					IsInvite: &boolTrue,
+				},
+			},
+		},
+	})
+	m.MatchResponse(t, res, m.MatchList("a", m.MatchV3Count(0)), m.MatchRoomSubscriptionsStrict(nil))
+
+	// now invite bob
+	alice.InviteRoom(t, inviteRoomID, bob.UserID)
+	// sync as bob until we see the room
+	res = bob.SlidingSyncUntilMembership(t, res.Pos, inviteRoomID, bob, "invite")
+	t.Logf("bob is invited")
+
+	// join the room
+	bob.JoinRoom(t, inviteRoomID, []string{})
+	res = bob.SlidingSyncUntilMembership(t, res.Pos, inviteRoomID, bob, "join")
+	t.Logf("bob joined")
+
+	// leave the room again, we should receive exactly one leave response
+	bob.LeaveRoom(t, inviteRoomID)
+	res = bob.SlidingSyncUntilMembership(t, res.Pos, inviteRoomID, bob, "leave")
+
+	if room, ok := res.Rooms[inviteRoomID]; ok {
+		if c := len(room.Timeline); c > 1 {
+			for _, ev := range res.Rooms[inviteRoomID].Timeline {
+				t.Logf("Event: %s", ev)
+			}
+			t.Fatalf("expected 1 timeline event, got %d", c)
+		}
+	} else {
+		t.Fatalf("expected room %s in response, but didn't find it", inviteRoomID)
+	}
+
+	res = bob.SlidingSync(t, sync3.Request{}, WithPos(res.Pos))
+
+	// this should not happen, as we already send down the leave event
+	if room, ok := res.Rooms[inviteRoomID]; ok {
+		for _, ev := range room.Timeline {
+			t.Logf("Event: %s", ev)
+		}
+		t.Fatalf("expected room not to be in response")
+	}
+}
+
 // test invite/join counts update and are accurate
 func TestMemberCounts(t *testing.T) {
 	alice := registerNewUser(t)

--- a/tests-e2e/membership_transitions_test.go
+++ b/tests-e2e/membership_transitions_test.go
@@ -455,7 +455,7 @@ func TestLeavingRoomReturnsOneEvent(t *testing.T) {
 			res = bob.SlidingSync(t, sync3.Request{}, WithPos(res.Pos))
 
 			// this should not happen, as we already send down the leave event
-			// If alice is synching, we run into this failure mode
+			// If alice is syncing, we run into this failure mode
 			if room, ok := res.Rooms[inviteRoomID]; ok {
 				for _, ev := range room.Timeline {
 					t.Logf("[multiple poller=%v] Event: %s", aliceSyncing, ev)
@@ -521,7 +521,7 @@ func TestRejectingInviteReturnsOneEvent(t *testing.T) {
 			res = bob.SlidingSync(t, sync3.Request{}, WithPos(res.Pos))
 
 			// this should not happen, as we already send down the leave event
-			// If alice is synching, we run into this failure mode
+			// If alice is syncing, we run into this failure mode
 			if room, ok := res.Rooms[inviteRoomID]; ok {
 				for _, ev := range room.Timeline {
 					t.Logf("[multiple poller=%v] Event: %s", aliceSyncing, ev)


### PR DESCRIPTION
Still investigating, but doesn't even seem to require multiple pollers as per https://github.com/matrix-org/sliding-sync/issues/250