### PR TITLE
Reuse existing connections

### DIFF
--- a/sync3/conn.go
+++ b/sync3/conn.go
@@ -62,6 +62,9 @@ type Conn struct {
 	mu                         *sync.Mutex
 	cancelOutstandingRequest   func()
 	cancelOutstandingRequestMu *sync.Mutex
+
+	// If we think this session is expired, e.g. due to the poller receiving HTTP 401
+	expired bool
 }
 
 func NewConn(connID ConnID, h ConnHandler) *Conn {
@@ -75,6 +78,10 @@ func NewConn(connID ConnID, h ConnHandler) *Conn {
 
 func (c *Conn) Alive() bool {
 	return c.handler.Alive()
+}
+
+func (c *Conn) Expired() bool {
+	return c.expired
 }
 
 func (c *Conn) OnUpdate(ctx context.Context, update caches.Update) {

--- a/sync3/handler/handler.go
+++ b/sync3/handler/handler.go
@@ -390,7 +390,7 @@ func (h *SyncLiveHandler) setupConnection(req *http.Request, syncReq *sync3.Requ
 			if !conn.Expired() { // if the connection is not expired, we should have a poller running
 				return req, conn, nil
 			}
-			// if the connection is expired, we most likely received a 401 from in the poller
+			// if the connection is expired, we most likely received a 401 in the poller
 			// and terminated the poller loop. Create a new one now below.
 		} else {
 			// conn doesn't exist, we probably nuked it.

--- a/tests-e2e/conns_test.go
+++ b/tests-e2e/conns_test.go
@@ -208,7 +208,8 @@ func TestOIDCReuseConnection(t *testing.T) {
 
 	// create a new AccessToken with the same deviceID to simulate a OIDC refresh
 	alice.Login(t, "password", alice.DeviceID)
-	res = alice.SlidingSyncUntilEvent(t, position, sync3.Request{
+	// Make sure we receive the event on our connection
+	alice.SlidingSyncUntilEvent(t, position, sync3.Request{
 		ConnID: "A", // make sure to reuse the connID
 	}, roomID, Event{ID: eventID})
 }


### PR DESCRIPTION
This should fix #274

Instead of closing all connections, we now set a `expired` flag. This, in combination with a `pos` in the request, is used to reuse existing connections.
If the client doesn't come back for 30min, the connection is expired as usual. (see [comment](https://github.com/matrix-org/sliding-sync/issues/274#issuecomment-1710347743))