### PR TITLE
bugfix: ensure that we always call EnsurePolling for expired tokens

### DIFF
--- a/sync3/handler/ensure_polling.go
+++ b/sync3/handler/ensure_polling.go
@@ -16,8 +16,8 @@ import (
 type pendingInfo struct {
 	// done is set to true when the EnsurePolling request received a response.
 	done bool
-	// success is true when done is true and EnsurePolling succeeded; otherwise false.
-	success bool
+	// expired is true when the token is expired. Any 'done'ness should be ignored for expired tokens.
+	expired bool
 	// ch is a dummy channel which never receives any data. A call to
 	// EnsurePoller.OnInitialSyncComplete will close the channel (unblocking any
 	// EnsurePoller.EnsurePolling calls which are waiting on it) and then set the ch
@@ -58,19 +58,31 @@ func NewEnsurePoller(notifier pubsub.Notifier, enablePrometheus bool) *EnsurePol
 }
 
 // EnsurePolling blocks until the V2InitialSyncComplete response is received for this device. It is
-// the caller's responsibility to call OnInitialSyncComplete when new events arrive. Returns the Success field from the
-// V2InitialSyncComplete response, which is true iff there is an active poller.
+// the caller's responsibility to call OnInitialSyncComplete when new events arrive. Returns whether
+// or not the token is expired
 func (p *EnsurePoller) EnsurePolling(ctx context.Context, pid sync2.PollerID, tokenHash string) bool {
 	ctx, region := internal.StartSpan(ctx, "EnsurePolling")
 	defer region.End()
 	p.mu.Lock()
-	// do we need to wait?
-	if p.pendingPolls[pid].done {
+	// do we need to wait? Expired devices ALWAYS need a fresh poll
+	expired := p.pendingPolls[pid].expired
+	if !expired && p.pendingPolls[pid].done {
 		internal.Logf(ctx, "EnsurePolling", "user %s device %s already done", pid.UserID, pid.DeviceID)
-		success := p.pendingPolls[pid].success
 		p.mu.Unlock()
-		return success
+		return expired // always false
 	}
+
+	// either we have expired or we haven't expired and are still waiting on the initial sync.
+	// If we have expired, nuke the pid from the map now so we will use the same code path as a fresh device sync
+	if expired {
+		// close any existing channel
+		if p.pendingPolls[pid].ch != nil {
+			close(p.pendingPolls[pid].ch)
+		}
+		delete(p.pendingPolls, pid)
+		// at this point, ch == nil so we will do an initial sync
+	}
+
 	// have we called EnsurePolling for this user/device before?
 	ch := p.pendingPolls[pid].ch
 	if ch != nil {
@@ -84,9 +96,9 @@ func (p *EnsurePoller) EnsurePolling(ctx context.Context, pid sync2.PollerID, to
 		<-ch
 		r2.End()
 		p.mu.Lock()
-		success := p.pendingPolls[pid].success
+		expired := p.pendingPolls[pid].expired
 		p.mu.Unlock()
-		return success
+		return expired
 	}
 	// Make a channel to wait until we have done an initial sync
 	ch = make(chan struct{})
@@ -110,9 +122,9 @@ func (p *EnsurePoller) EnsurePolling(ctx context.Context, pid sync2.PollerID, to
 	r2.End()
 
 	p.mu.Lock()
-	success := p.pendingPolls[pid].success
+	expired = p.pendingPolls[pid].expired
 	p.mu.Unlock()
-	return success
+	return expired
 }
 
 func (p *EnsurePoller) OnInitialSyncComplete(payload *pubsub.V2InitialSyncComplete) {
@@ -129,7 +141,7 @@ func (p *EnsurePoller) OnInitialSyncComplete(payload *pubsub.V2InitialSyncComple
 		log.Trace().Msg("OnInitialSyncComplete: we weren't waiting for this")
 		p.pendingPolls[pid] = pendingInfo{
 			done:    true,
-			success: payload.Success,
+			expired: !payload.Success,
 		}
 		return
 	}
@@ -143,7 +155,7 @@ func (p *EnsurePoller) OnInitialSyncComplete(payload *pubsub.V2InitialSyncComple
 	ch := pending.ch
 	pending.done = true
 	pending.ch = nil
-	pending.success = payload.Success
+	pending.expired = !payload.Success
 	p.pendingPolls[pid] = pending
 	p.calculateNumOutstanding() // decrement total
 	log.Trace().Msg("OnInitialSyncComplete: closing channel")
@@ -159,10 +171,12 @@ func (p *EnsurePoller) OnExpiredToken(payload *pubsub.V2ExpiredToken) {
 		// We weren't tracking the state of this poller, so we have nothing to clean up.
 		return
 	}
-	if pending.ch != nil {
-		close(pending.ch)
-	}
-	delete(p.pendingPolls, pid)
+	pending.expired = true
+	p.pendingPolls[pid] = pending
+
+	// We used to delete the entry from the map at this point to force the next
+	// EnsurePolling call to do a fresh EnsurePolling request, but now we do that
+	// by signalling via the expired flag.
 }
 
 func (p *EnsurePoller) Teardown() {

--- a/sync3/handler/ensure_polling.go
+++ b/sync3/handler/ensure_polling.go
@@ -155,7 +155,11 @@ func (p *EnsurePoller) OnInitialSyncComplete(payload *pubsub.V2InitialSyncComple
 	ch := pending.ch
 	pending.done = true
 	pending.ch = nil
-	pending.expired = !payload.Success
+	// If for whatever reason we get OnExpiredToken prior to OnInitialSyncComplete, don't forget that
+	// we expired the token i.e expiry latches true.
+	if !pending.expired {
+		pending.expired = !payload.Success
+	}
 	p.pendingPolls[pid] = pending
 	p.calculateNumOutstanding() // decrement total
 	log.Trace().Msg("OnInitialSyncComplete: closing channel")

--- a/sync3/handler/ensure_polling_test.go
+++ b/sync3/handler/ensure_polling_test.go
@@ -1,0 +1,137 @@
+package handler
+
+import (
+	"context"
+	"reflect"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/matrix-org/sliding-sync/pubsub"
+	"github.com/matrix-org/sliding-sync/sync2"
+)
+
+type mockNotifier struct {
+	ch chan pubsub.Payload
+}
+
+func (n *mockNotifier) Notify(chanName string, p pubsub.Payload) error {
+	n.ch <- p
+	return nil
+}
+
+func (n *mockNotifier) Close() error {
+	return nil
+}
+
+func (n *mockNotifier) MustHaveNoSentPayloads(t *testing.T) {
+	t.Helper()
+	if len(n.ch) == 0 {
+		return
+	}
+	t.Fatalf("MustHaveNoSentPayloads: %d in buffer", len(n.ch))
+}
+
+func (n *mockNotifier) WaitForNextPayload(t *testing.T, timeout time.Duration) pubsub.Payload {
+	t.Helper()
+	select {
+	case p := <-n.ch:
+		return p
+	case <-time.After(timeout):
+		t.Fatalf("WaitForNextPayload: timed out after %v", timeout)
+	}
+	panic("unreachable")
+}
+
+// check that the request/response works and unblocks things correctly
+func TestEnsurePollerBasicWorks(t *testing.T) {
+	n := &mockNotifier{ch: make(chan pubsub.Payload, 100)}
+	ctx := context.Background()
+	pid := sync2.PollerID{UserID: "@alice:localhost", DeviceID: "DEVICE"}
+	tokHash := "tokenHash"
+	ep := NewEnsurePoller(n, false)
+
+	var expired atomic.Bool
+	finished := make(chan bool) // dummy
+	go func() {
+		exp := ep.EnsurePolling(ctx, pid, tokHash)
+		expired.Store(exp)
+		close(finished)
+	}()
+
+	p := n.WaitForNextPayload(t, time.Second)
+
+	// check it's a V3EnsurePolling payload
+	pp, ok := p.(*pubsub.V3EnsurePolling)
+	if !ok {
+		t.Fatalf("unexpected payload: %+v", p)
+	}
+	assertVal(t, pp.UserID, pid.UserID)
+	assertVal(t, pp.DeviceID, pid.DeviceID)
+	assertVal(t, pp.AccessTokenHash, tokHash)
+
+	// make sure we're still waiting
+	select {
+	case <-finished:
+		t.Fatalf("EnsurePolling unblocked before response was sent")
+	default:
+	}
+
+	// send back the response
+	ep.OnInitialSyncComplete(&pubsub.V2InitialSyncComplete{
+		UserID:   pid.UserID,
+		DeviceID: pid.DeviceID,
+		Success:  true,
+	})
+
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatalf("EnsurePolling didn't unblock after response was sent")
+	}
+
+	if expired.Load() {
+		t.Fatalf("response said token was expired when it wasn't")
+	}
+}
+
+func TestEnsurePollerCachesResponses(t *testing.T) {
+	n := &mockNotifier{ch: make(chan pubsub.Payload, 100)}
+	ctx := context.Background()
+	pid := sync2.PollerID{UserID: "@alice:localhost", DeviceID: "DEVICE"}
+	ep := NewEnsurePoller(n, false)
+
+	finished := make(chan bool) // dummy
+	go func() {
+		_ = ep.EnsurePolling(ctx, pid, "tokenHash")
+		close(finished)
+	}()
+
+	n.WaitForNextPayload(t, time.Second) // wait for V3EnsurePolling
+	// send back the response
+	ep.OnInitialSyncComplete(&pubsub.V2InitialSyncComplete{
+		UserID:   pid.UserID,
+		DeviceID: pid.DeviceID,
+		Success:  true,
+	})
+
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatalf("EnsurePolling didn't unblock after response was sent")
+	}
+
+	// hitting EnsurePolling again should immediately return
+	exp := ep.EnsurePolling(ctx, pid, "tokenHash")
+	if exp {
+		t.Fatalf("EnsurePolling said token was expired when it wasn't")
+	}
+	n.MustHaveNoSentPayloads(t)
+}
+
+func assertVal(t *testing.T, got, want interface{}) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("assertVal: got %v want %v", got, want)
+	}
+}

--- a/sync3/handler/ensure_polling_test.go
+++ b/sync3/handler/ensure_polling_test.go
@@ -129,6 +129,71 @@ func TestEnsurePollerCachesResponses(t *testing.T) {
 	n.MustHaveNoSentPayloads(t)
 }
 
+// Regression test for when we did cache failures, causing no poller to start for the device
+func TestEnsurePollerDoesntCacheFailures(t *testing.T) {
+	n := &mockNotifier{ch: make(chan pubsub.Payload, 100)}
+	ctx := context.Background()
+	pid := sync2.PollerID{UserID: "@alice:localhost", DeviceID: "DEVICE"}
+	ep := NewEnsurePoller(n, false)
+
+	finished := make(chan bool) // dummy
+	var expired atomic.Bool
+	go func() {
+		exp := ep.EnsurePolling(ctx, pid, "tokenHash")
+		expired.Store(exp)
+		close(finished)
+	}()
+
+	n.WaitForNextPayload(t, time.Second) // wait for V3EnsurePolling
+	// send back the response, which failed
+	ep.OnInitialSyncComplete(&pubsub.V2InitialSyncComplete{
+		UserID:   pid.UserID,
+		DeviceID: pid.DeviceID,
+		Success:  false,
+	})
+
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatalf("EnsurePolling didn't unblock after response was sent")
+	}
+	if !expired.Load() {
+		t.Fatalf("EnsurePolling returned not expired, wanted expired due to Success=false")
+	}
+
+	// hitting EnsurePolling again should do a new request (i.e not cached the failure)
+	var expiredAgain atomic.Bool
+	finished = make(chan bool) // dummy
+	go func() {
+		exp := ep.EnsurePolling(ctx, pid, "tokenHash")
+		expiredAgain.Store(exp)
+		close(finished)
+	}()
+
+	p := n.WaitForNextPayload(t, time.Second) // wait for V3EnsurePolling
+	// check it's a V3EnsurePolling payload
+	pp, ok := p.(*pubsub.V3EnsurePolling)
+	if !ok {
+		t.Fatalf("unexpected payload: %+v", p)
+	}
+	assertVal(t, pp.UserID, pid.UserID)
+	assertVal(t, pp.DeviceID, pid.DeviceID)
+	assertVal(t, pp.AccessTokenHash, "tokenHash")
+
+	// send back the response, which succeeded this time
+	ep.OnInitialSyncComplete(&pubsub.V2InitialSyncComplete{
+		UserID:   pid.UserID,
+		DeviceID: pid.DeviceID,
+		Success:  true,
+	})
+
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatalf("EnsurePolling didn't unblock after response was sent")
+	}
+}
+
 func assertVal(t *testing.T, got, want interface{}) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {

--- a/sync3/handler/handler.go
+++ b/sync3/handler/handler.go
@@ -396,8 +396,8 @@ func (h *SyncLiveHandler) setupConnection(req *http.Request, syncReq *sync3.Requ
 
 	pid := sync2.PollerID{UserID: token.UserID, DeviceID: token.DeviceID}
 	log.Trace().Any("pid", pid).Msg("checking poller exists and is running")
-	success := h.EnsurePoller.EnsurePolling(req.Context(), pid, token.AccessTokenHash)
-	if !success {
+	expiredToken := h.EnsurePoller.EnsurePolling(req.Context(), pid, token.AccessTokenHash)
+	if expiredToken {
 		log.Error().Msg("EnsurePolling failed, returning 401")
 		// Assumption: the only way that EnsurePolling fails is if the access token is invalid.
 		return req, nil, &internal.HandlerError{


### PR DESCRIPTION
Otherwise, we might cache that the token is expired and never let a new token start the poller again.