### PR TITLE
Add posibility to request room heroes

### DIFF
--- a/internal/roomname_test.go
+++ b/internal/roomname_test.go
@@ -11,7 +11,8 @@ func TestCalculateRoomName(t *testing.T) {
 		invitedCount       int
 		maxNumNamesPerRoom int
 
-		wantRoomName string
+		wantRoomName   string
+		wantCalculated bool
 	}{
 		// Room name takes precedence
 		{
@@ -65,7 +66,8 @@ func TestCalculateRoomName(t *testing.T) {
 					Name: "Bob",
 				},
 			},
-			wantRoomName: "Alice, Bob and 3 others",
+			wantRoomName:   "Alice, Bob and 3 others",
+			wantCalculated: true,
 		},
 		// Small group chat
 		{
@@ -86,7 +88,8 @@ func TestCalculateRoomName(t *testing.T) {
 					Name: "Charlie",
 				},
 			},
-			wantRoomName: "Alice, Bob and Charlie",
+			wantRoomName:   "Alice, Bob and Charlie",
+			wantCalculated: true,
 		},
 		// DM room
 		{
@@ -99,7 +102,8 @@ func TestCalculateRoomName(t *testing.T) {
 					Name: "Alice",
 				},
 			},
-			wantRoomName: "Alice",
+			wantRoomName:   "Alice",
+			wantCalculated: true,
 		},
 		// 3-way room
 		{
@@ -116,7 +120,8 @@ func TestCalculateRoomName(t *testing.T) {
 					Name: "Bob",
 				},
 			},
-			wantRoomName: "Alice and Bob",
+			wantRoomName:   "Alice and Bob",
+			wantCalculated: true,
 		},
 		// 3-way room, one person invited with no display name
 		{
@@ -132,7 +137,8 @@ func TestCalculateRoomName(t *testing.T) {
 					ID: "@bob:localhost",
 				},
 			},
-			wantRoomName: "Alice and @bob:localhost",
+			wantRoomName:   "Alice and @bob:localhost",
+			wantCalculated: true,
 		},
 		// 3-way room, no display names
 		{
@@ -147,7 +153,8 @@ func TestCalculateRoomName(t *testing.T) {
 					ID: "@bob:localhost",
 				},
 			},
-			wantRoomName: "@alice:localhost and @bob:localhost",
+			wantRoomName:   "@alice:localhost and @bob:localhost",
+			wantCalculated: true,
 		},
 		// disambiguation all
 		{
@@ -168,7 +175,8 @@ func TestCalculateRoomName(t *testing.T) {
 					Name: "Alice",
 				},
 			},
-			wantRoomName: "Alice (@alice:localhost), Alice (@bob:localhost), Alice (@charlie:localhost) and 6 others",
+			wantRoomName:   "Alice (@alice:localhost), Alice (@bob:localhost), Alice (@charlie:localhost) and 6 others",
+			wantCalculated: true,
 		},
 		// disambiguation some
 		{
@@ -189,7 +197,8 @@ func TestCalculateRoomName(t *testing.T) {
 					Name: "Alice",
 				},
 			},
-			wantRoomName: "Alice (@alice:localhost), Bob, Alice (@charlie:localhost) and 6 others",
+			wantRoomName:   "Alice (@alice:localhost), Bob, Alice (@charlie:localhost) and 6 others",
+			wantCalculated: true,
 		},
 		// disambiguation, faking user IDs as display names
 		{
@@ -205,7 +214,8 @@ func TestCalculateRoomName(t *testing.T) {
 					ID: "@alice:localhost",
 				},
 			},
-			wantRoomName: "@alice:localhost (@evil:localhost) and @alice:localhost (@alice:localhost)",
+			wantRoomName:   "@alice:localhost (@evil:localhost) and @alice:localhost (@alice:localhost)",
+			wantCalculated: true,
 		},
 		// left room
 		{
@@ -222,7 +232,8 @@ func TestCalculateRoomName(t *testing.T) {
 					Name: "Bob",
 				},
 			},
-			wantRoomName: "Empty Room (was Alice and Bob)",
+			wantRoomName:   "Empty Room (was Alice and Bob)",
+			wantCalculated: true,
 		},
 		// empty room
 		{
@@ -235,7 +246,7 @@ func TestCalculateRoomName(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		gotName := CalculateRoomName(&RoomMetadata{
+		gotName, gotCalculated := CalculateRoomName(&RoomMetadata{
 			NameEvent:      tc.roomName,
 			CanonicalAlias: tc.canonicalAlias,
 			Heroes:         tc.heroes,
@@ -244,6 +255,9 @@ func TestCalculateRoomName(t *testing.T) {
 		}, tc.maxNumNamesPerRoom)
 		if gotName != tc.wantRoomName {
 			t.Errorf("got %s want %s for test case: %+v", gotName, tc.wantRoomName, tc)
+		}
+		if gotCalculated != tc.wantCalculated {
+			t.Errorf("got %v want %v for test case: %+v", gotCalculated, tc.wantCalculated, tc)
 		}
 	}
 }

--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -680,7 +680,7 @@ func (s *ConnState) getInitialRoomData(ctx context.Context, roomSub sync3.RoomSu
 			PrevBatch:         userRoomData.RequestedLatestEvents.PrevBatch,
 			Timestamp:         maxTs,
 		}
-		if calculated {
+		if roomSub.IncludeHeroes() && calculated {
 			room.Heroes = metadata.Heroes
 		}
 		rooms[roomID] = room

--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -664,8 +664,9 @@ func (s *ConnState) getInitialRoomData(ctx context.Context, roomSub sync3.RoomSu
 			}
 		}
 
-		rooms[roomID] = sync3.Room{
-			Name:              internal.CalculateRoomName(metadata, 5), // TODO: customisable?
+		roomName, calculated := internal.CalculateRoomName(metadata, 5) // TODO: customisable?
+		room := sync3.Room{
+			Name:              roomName,
 			AvatarChange:      sync3.NewAvatarChange(internal.CalculateAvatar(metadata)),
 			NotificationCount: int64(userRoomData.NotificationCount),
 			HighlightCount:    int64(userRoomData.HighlightCount),
@@ -679,6 +680,10 @@ func (s *ConnState) getInitialRoomData(ctx context.Context, roomSub sync3.RoomSu
 			PrevBatch:         userRoomData.RequestedLatestEvents.PrevBatch,
 			Timestamp:         maxTs,
 		}
+		if calculated {
+			room.Heroes = metadata.Heroes
+		}
+		rooms[roomID] = room
 	}
 
 	if rsm.IsLazyLoading() {

--- a/sync3/handler/connstate_live.go
+++ b/sync3/handler/connstate_live.go
@@ -262,7 +262,8 @@ func (s *connStateLive) processLiveUpdate(ctx context.Context, up caches.Update,
 				roomName, calculated := internal.CalculateRoomName(metadata, 5) // TODO: customisable?
 
 				thisRoom.Name = roomName
-				if calculated {
+
+				if s.roomSubscriptions[roomUpdate.RoomID()].IncludeHeroes() && calculated {
 					thisRoom.Heroes = metadata.Heroes
 				}
 			}

--- a/sync3/handler/connstate_live.go
+++ b/sync3/handler/connstate_live.go
@@ -259,7 +259,12 @@ func (s *connStateLive) processLiveUpdate(ctx context.Context, up caches.Update,
 			if delta.RoomNameChanged {
 				metadata := roomUpdate.GlobalRoomMetadata()
 				metadata.RemoveHero(s.userID)
-				thisRoom.Name = internal.CalculateRoomName(metadata, 5) // TODO: customisable?
+				roomName, calculated := internal.CalculateRoomName(metadata, 5) // TODO: customisable?
+
+				thisRoom.Name = roomName
+				if calculated {
+					thisRoom.Heroes = metadata.Heroes
+				}
 			}
 			if delta.RoomAvatarChanged {
 				metadata := roomUpdate.GlobalRoomMetadata()

--- a/sync3/lists.go
+++ b/sync3/lists.go
@@ -70,8 +70,9 @@ func (s *InternalRequestLists) SetRoom(r RoomConnMetadata) (delta RoomDelta) {
 		delta.RoomNameChanged = !existing.SameRoomName(&r.RoomMetadata)
 		if delta.RoomNameChanged {
 			// update the canonical name to allow room name sorting to continue to work
+			roomName, _ := internal.CalculateRoomName(&r.RoomMetadata, 5)
 			r.CanonicalisedName = strings.ToLower(
-				strings.Trim(internal.CalculateRoomName(&r.RoomMetadata, 5), "#!():_@"),
+				strings.Trim(roomName, "#!():_@"),
 			)
 		} else {
 			// XXX: during TestConnectionTimeoutNotReset there is some situation where
@@ -109,8 +110,9 @@ func (s *InternalRequestLists) SetRoom(r RoomConnMetadata) (delta RoomDelta) {
 		}
 	} else {
 		// set the canonical name to allow room name sorting to work
+		roomName, _ := internal.CalculateRoomName(&r.RoomMetadata, 5)
 		r.CanonicalisedName = strings.ToLower(
-			strings.Trim(internal.CalculateRoomName(&r.RoomMetadata, 5), "#!():_@"),
+			strings.Trim(roomName, "#!():_@"),
 		)
 		r.ResolvedAvatarURL = internal.CalculateAvatar(&r.RoomMetadata)
 		// We'll automatically use the LastInterestedEventTimestamps provided by the

--- a/sync3/request.go
+++ b/sync3/request.go
@@ -57,6 +57,7 @@ type RequestList struct {
 	SlowGetAllRooms *bool           `json:"slow_get_all_rooms,omitempty"`
 	Deleted         bool            `json:"deleted,omitempty"`
 	BumpEventTypes  []string        `json:"bump_event_types"`
+	Heroes          bool            `json:"heroes"`
 }
 
 func (rl *RequestList) ShouldGetAllRooms() bool {
@@ -517,7 +518,8 @@ func (rf *RequestFilters) Include(r *RoomConnMetadata, finder RoomFinder) bool {
 	if rf.IsInvite != nil && *rf.IsInvite != r.IsInvite {
 		return false
 	}
-	if rf.RoomNameFilter != "" && !strings.Contains(strings.ToLower(internal.CalculateRoomName(&r.RoomMetadata, 5)), strings.ToLower(rf.RoomNameFilter)) {
+	roomName, _ := internal.CalculateRoomName(&r.RoomMetadata, 5)
+	if rf.RoomNameFilter != "" && !strings.Contains(strings.ToLower(roomName), strings.ToLower(rf.RoomNameFilter)) {
 		return false
 	}
 	if len(rf.NotTags) > 0 {

--- a/sync3/request.go
+++ b/sync3/request.go
@@ -57,7 +57,6 @@ type RequestList struct {
 	SlowGetAllRooms *bool           `json:"slow_get_all_rooms,omitempty"`
 	Deleted         bool            `json:"deleted,omitempty"`
 	BumpEventTypes  []string        `json:"bump_event_types"`
-	Heroes          bool            `json:"heroes"`
 }
 
 func (rl *RequestList) ShouldGetAllRooms() bool {
@@ -395,12 +394,17 @@ func (r *Request) ApplyDelta(nextReq *Request) (result *Request, delta *RequestD
 		if bumpEventTypes == nil {
 			bumpEventTypes = existingList.BumpEventTypes
 		}
+		heroes := nextList.Heroes
+		if heroes == nil {
+			heroes = existingList.Heroes
+		}
 
 		calculatedLists[listKey] = RequestList{
 			RoomSubscription: RoomSubscription{
 				RequiredState:   reqState,
 				TimelineLimit:   timelineLimit,
 				IncludeOldRooms: includeOldRooms,
+				Heroes:          heroes,
 			},
 			Ranges:          rooms,
 			Sort:            sort,
@@ -565,6 +569,7 @@ type RoomSubscription struct {
 	RequiredState   [][2]string       `json:"required_state"`
 	TimelineLimit   int64             `json:"timeline_limit"`
 	IncludeOldRooms *RoomSubscription `json:"include_old_rooms"`
+	Heroes          *bool             `json:"heroes"`
 }
 
 func (rs RoomSubscription) RequiredStateChanged(other RoomSubscription) bool {
@@ -586,6 +591,10 @@ func (rs RoomSubscription) LazyLoadMembers() bool {
 		}
 	}
 	return false
+}
+
+func (rs RoomSubscription) IncludeHeroes() bool {
+	return rs.Heroes != nil && *rs.Heroes
 }
 
 // Combine this subcription with another, returning a union of both as a copy.

--- a/sync3/room.go
+++ b/sync3/room.go
@@ -11,6 +11,7 @@ import (
 type Room struct {
 	Name              string            `json:"name,omitempty"`
 	AvatarChange      AvatarChange      `json:"avatar,omitempty"`
+	Heroes            []internal.Hero   `json:"heroes,omitempty"`
 	RequiredState     []json.RawMessage `json:"required_state,omitempty"`
 	Timeline          []json.RawMessage `json:"timeline,omitempty"`
 	InviteState       []json.RawMessage `json:"invite_state,omitempty"`

--- a/tests-e2e/client_test.go
+++ b/tests-e2e/client_test.go
@@ -695,6 +695,7 @@ func (c *CSAPI) SlidingSyncUntilMembership(t *testing.T, pos string, roomID stri
 			RoomSubscriptions: map[string]sync3.RoomSubscription{
 				roomID: {
 					TimelineLimit: 10,
+					Heroes:        &boolTrue,
 				},
 			},
 		}, func(r *sync3.Response) error {
@@ -713,6 +714,7 @@ func (c *CSAPI) SlidingSyncUntilMembership(t *testing.T, pos string, roomID stri
 		RoomSubscriptions: map[string]sync3.RoomSubscription{
 			roomID: {
 				TimelineLimit: 10,
+				Heroes:        &boolTrue,
 			},
 		},
 	}, func(r *sync3.Response) error {

--- a/tests-e2e/membership_transitions_test.go
+++ b/tests-e2e/membership_transitions_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/matrix-org/sliding-sync/sync3"
 	"github.com/matrix-org/sliding-sync/testutils/m"
+	"github.com/tidwall/gjson"
 )
 
 func TestRoomStateTransitions(t *testing.T) {
@@ -618,6 +619,45 @@ func TestHeroesOnMembershipChanges(t *testing.T) {
 		res := alice.SlidingSyncUntilMembership(t, "", aliasRoomID, bob, "join")
 		if len(res.Rooms[aliasRoomID].Heroes) > 0 {
 			t.Errorf("expected no heroes, got %#v", res.Rooms[aliasRoomID].Heroes)
+		}
+	})
+
+	t.Run("can set heroes=true on room subscriptions", func(t *testing.T) {
+		subRoomID := alice.CreateRoom(t, map[string]interface{}{"preset": "public_chat"})
+		bob.JoinRoom(t, subRoomID, []string{})
+
+		// Start without requesting heroes
+		res := alice.SlidingSyncUntil(t, "", sync3.Request{
+			RoomSubscriptions: map[string]sync3.RoomSubscription{
+				subRoomID: {
+					TimelineLimit: 10,
+					Heroes:        &boolTrue,
+				},
+			},
+		}, func(response *sync3.Response) error {
+			r, ok := response.Rooms[subRoomID]
+			if !ok {
+				return fmt.Errorf("room %q not in response", subRoomID)
+			}
+			// wait for bob to be joined
+			for _, ev := range r.Timeline {
+				if gjson.GetBytes(ev, "type").Str != "m.room.member" {
+					continue
+				}
+				if gjson.GetBytes(ev, "state_key").Str != bob.UserID {
+					continue
+				}
+				if gjson.GetBytes(ev, "content.membership").Str == "join" {
+					return nil
+				}
+			}
+			return fmt.Errorf("%s is not joined to room %q", bob.UserID, subRoomID)
+		})
+		if c := len(res.Rooms[subRoomID].Heroes); c > 1 {
+			t.Errorf("expected 1 room hero, got %d", c)
+		}
+		if gotUserID := res.Rooms[subRoomID].Heroes[0].ID; gotUserID != bob.UserID {
+			t.Errorf("expected userID %q, got %q", gotUserID, bob.UserID)
 		}
 	})
 }

--- a/tests-e2e/membership_transitions_test.go
+++ b/tests-e2e/membership_transitions_test.go
@@ -626,7 +626,6 @@ func TestHeroesOnMembershipChanges(t *testing.T) {
 		subRoomID := alice.CreateRoom(t, map[string]interface{}{"preset": "public_chat"})
 		bob.JoinRoom(t, subRoomID, []string{})
 
-		// Start without requesting heroes
 		res := alice.SlidingSyncUntil(t, "", sync3.Request{
 			RoomSubscriptions: map[string]sync3.RoomSubscription{
 				subRoomID: {

--- a/tests-e2e/membership_transitions_test.go
+++ b/tests-e2e/membership_transitions_test.go
@@ -532,6 +532,96 @@ func TestRejectingInviteReturnsOneEvent(t *testing.T) {
 	}
 }
 
+// Test to check that room heroes are returned if the membership changes
+func TestHeroesOnMembershipChanges(t *testing.T) {
+	alice := registerNewUser(t)
+	bob := registerNewUser(t)
+	charlie := registerNewUser(t)
+
+	t.Run("nameless room uses heroes to calculate roomname", func(t *testing.T) {
+		// create a room without a name, to ensure we calculate the room name based on
+		// room heroes
+		roomID := alice.CreateRoom(t, map[string]interface{}{"preset": "public_chat"})
+
+		bob.JoinRoom(t, roomID, []string{})
+
+		res := alice.SlidingSyncUntilMembership(t, "", roomID, bob, "join")
+		// we expect to see Bob as a hero
+		if c := len(res.Rooms[roomID].Heroes); c > 1 {
+			t.Errorf("expected 1 room hero, got %d", c)
+		}
+		if gotUserID := res.Rooms[roomID].Heroes[0].ID; gotUserID != bob.UserID {
+			t.Errorf("expected userID %q, got %q", gotUserID, bob.UserID)
+		}
+
+		// Now join with Charlie, the heroes and the room name should change
+		charlie.JoinRoom(t, roomID, []string{})
+		res = alice.SlidingSyncUntilMembership(t, res.Pos, roomID, charlie, "join")
+
+		// we expect to see Bob as a hero
+		if c := len(res.Rooms[roomID].Heroes); c > 2 {
+			t.Errorf("expected 2 room hero, got %d", c)
+		}
+		if gotUserID := res.Rooms[roomID].Heroes[0].ID; gotUserID != bob.UserID {
+			t.Errorf("expected userID %q, got %q", gotUserID, bob.UserID)
+		}
+		if gotUserID := res.Rooms[roomID].Heroes[1].ID; gotUserID != charlie.UserID {
+			t.Errorf("expected userID %q, got %q", gotUserID, charlie.UserID)
+		}
+
+		// Send a message, the heroes shouldn't change
+		msgEv := bob.SendEventSynced(t, roomID, Event{
+			Type:    "m.room.roomID",
+			Content: map[string]interface{}{"body": "Hello world", "msgtype": "m.text"},
+		})
+
+		res = alice.SlidingSyncUntilEventID(t, res.Pos, roomID, msgEv)
+		if len(res.Rooms[roomID].Heroes) > 0 {
+			t.Errorf("expected no change to room heros")
+		}
+
+		// Now leave with Charlie, only Bob should be in the heroes list
+		charlie.LeaveRoom(t, roomID)
+		res = alice.SlidingSyncUntilMembership(t, res.Pos, roomID, charlie, "leave")
+		if c := len(res.Rooms[roomID].Heroes); c > 1 {
+			t.Errorf("expected 1 room hero, got %d", c)
+		}
+		if gotUserID := res.Rooms[roomID].Heroes[0].ID; gotUserID != bob.UserID {
+			t.Errorf("expected userID %q, got %q", gotUserID, bob.UserID)
+		}
+	})
+
+	t.Run("named rooms don't have heroes", func(t *testing.T) {
+		namedRoomID := alice.CreateRoom(t, map[string]interface{}{"preset": "public_chat", "name": "my room without heroes"})
+		// this makes sure that even if bob is joined, we don't return any heroes
+		bob.JoinRoom(t, namedRoomID, []string{})
+
+		res := alice.SlidingSyncUntilMembership(t, "", namedRoomID, bob, "join")
+		if len(res.Rooms[namedRoomID].Heroes) > 0 {
+			t.Errorf("expected no heroes, got %#v", res.Rooms[namedRoomID].Heroes)
+		}
+	})
+
+	t.Run("rooms with aliases don't have heroes", func(t *testing.T) {
+		aliasRoomID := alice.CreateRoom(t, map[string]interface{}{"preset": "public_chat"})
+
+		alias := fmt.Sprintf("#%s-%d:%s", t.Name(), time.Now().Unix(), alice.Domain)
+		alice.MustDoFunc(t, "PUT", []string{"_matrix", "client", "v3", "directory", "room", alias},
+			WithJSONBody(t, map[string]any{"room_id": aliasRoomID}),
+		)
+		alice.SetState(t, aliasRoomID, "m.room.canonical_alias", "", map[string]any{
+			"alias": alias,
+		})
+
+		bob.JoinRoom(t, aliasRoomID, []string{})
+
+		res := alice.SlidingSyncUntilMembership(t, "", aliasRoomID, bob, "join")
+		if len(res.Rooms[aliasRoomID].Heroes) > 0 {
+			t.Errorf("expected no heroes, got %#v", res.Rooms[aliasRoomID].Heroes)
+		}
+	})
+}
+
 // test invite/join counts update and are accurate
 func TestMemberCounts(t *testing.T) {
 	alice := registerNewUser(t)


### PR DESCRIPTION
Fixes https://github.com/matrix-org/sliding-sync/issues/241

Draft until I update the MSC

This adds a `heroes` flag to `RoomSubscription`s. If the room name was calculated using room heroes, the response for the room also contains an array of `heroes`, containing the `user_id`, and optionally the fields `displayname` and `avatar_url`.