### PR TITLE
Initialise: make snapshots instead of prepending state events

### DIFF
--- a/state/accumulator.go
+++ b/state/accumulator.go
@@ -165,13 +165,13 @@ type InitialiseResult struct {
 //     is unknown to the proxy. (We choose to ignore the possibility that a poller is
 //     slow and gives us e.g. a subset of current room state.)
 //
-//  2. Fetch the current state of the room, as a map from (type, state_key) to event.
+//  3. Fetch the current state of the room, as a map from (type, state_key) to event.
 //     If there is no existing state snapshot, this map is the empty map.
 //
 //     If the state hasn't altered, bail.
 //
 //  4. Create new snapshot.
-//      Update the map from (2) with the events in  in `state`.  (There must be similar logic already in A ccumulate for this?)
+//      Update the map from (3) with the events in  in `state`.  (There must be similar logic already in A ccumulate for this?)
 //      Store the snapshot. Mark the room's current state as being this snapshot.
 //
 // 5. If the starting snapshot ID was not zero, emit a cache invalidation payload.

--- a/state/accumulator.go
+++ b/state/accumulator.go
@@ -149,19 +149,33 @@ type InitialiseResult struct {
 	PrependTimelineEvents []json.RawMessage
 }
 
-// Initialise starts a new sync accumulator for the given room using the given state as a baseline.
+// Initialise processes the state block of a V2 sync response for a particular room. If
+// the state of the room has changed, we persist any new state events and create a new
+// "snapshot" of its entire state.
 //
-// This will only take effect if this is the first time the v3 server has seen this room, and it wasn't
-// possible to get all events up to the create event (e.g Matrix HQ).
-// This function:
-// - Stores these events
-// - Sets up the current snapshot based on the state list given.
+// Summary of the logic:
 //
-// If the v3 server has seen this room before, this function
-//   - queries the DB to determine which state events are known to th server,
-//   - returns (via InitialiseResult.PrependTimelineEvents) a slice of unknown state events,
+//  0. Ensure the state block is not empty.
 //
-// and otherwise does nothing.
+//  1. Capture the current snapshot ID, possibly zero. If it is zero, ensure that the
+//      state block contains a `create event`.
+//
+//  2. Insert the events and determine if the state block alters the current state of
+//     the room from the proxy's POV. This is the case iff some event in the state block
+//     is unknown to the proxy. (We choose to ignore the possibility that a poller is
+//     slow and gives us e.g. a subset of current room state.)
+//
+//  2. Fetch the current state of the room, as a map from (type, state_key) to event.
+//     If there is no existing state snapshot, this map is the empty map.
+//
+//     If the state hasn't altered, bail.
+//
+//  4. Create new snapshot.
+//      Update the map from (2) with the events in  in `state`.  (There must be similar logic already in A ccumulate for this?)
+//      Store the snapshot. Mark the room's current state as being this snapshot.
+//
+// 5. If the starting snapshot ID was not zero, emit a cache invalidation payload.
+
 func (a *Accumulator) Initialise(roomID string, state []json.RawMessage) (InitialiseResult, error) {
 	var res InitialiseResult
 	if len(state) == 0 {
@@ -172,36 +186,8 @@ func (a *Accumulator) Initialise(roomID string, state []json.RawMessage) (Initia
 		// we don't race with multiple calls to Initialise with the same room ID.
 		snapshotID, err := a.roomsTable.CurrentAfterSnapshotID(txn, roomID)
 		if err != nil {
-			return fmt.Errorf("error fetching snapshot id for room %s: %s", roomID, err)
+			return fmt.Errorf("error fetching snapshot id for room %s: %w", roomID, err)
 		}
-		if snapshotID > 0 {
-			// Poller A has received a gappy sync v2 response with a state block, and
-			// we have seen this room before. If we knew for certain that there is some
-			// other active poller B in this room then we could safely skip this logic.
-
-			// Log at debug for now. If we find an unknown event, we'll return it so
-			// that the poller can log a warning.
-			logger.Debug().Str("room_id", roomID).Int64("snapshot_id", snapshotID).Msg("Accumulator.Initialise called with incremental state but current snapshot already exists.")
-			eventIDs := make([]string, len(state))
-			eventIDToRawEvent := make(map[string]json.RawMessage, len(state))
-			for i := range state {
-				eventID := gjson.ParseBytes(state[i]).Get("event_id")
-				if !eventID.Exists() || eventID.Type != gjson.String {
-					return fmt.Errorf("Event %d lacks an event ID", i)
-				}
-				eventIDToRawEvent[eventID.Str] = state[i]
-				eventIDs[i] = eventID.Str
-			}
-			unknownEventIDs, err := a.eventsTable.SelectUnknownEventIDs(txn, eventIDs)
-			if err != nil {
-				return fmt.Errorf("error determing which event IDs are unknown: %s", err)
-			}
-			for unknownEventID := range unknownEventIDs {
-				res.PrependTimelineEvents = append(res.PrependTimelineEvents, eventIDToRawEvent[unknownEventID])
-			}
-			return nil
-		}
-
 		// We don't have a snapshot for this room. Parse the events first.
 		events := make([]Event, len(state))
 		for i := range events {
@@ -213,71 +199,65 @@ func (a *Accumulator) Initialise(roomID string, state []json.RawMessage) (Initia
 		}
 		events = filterAndEnsureFieldsSet(events)
 		if len(events) == 0 {
-			return fmt.Errorf("failed to insert events, all events were filtered out: %w", err)
+			return fmt.Errorf("failed to parse state block, all events were filtered out: %w", err)
 		}
 
-		// Before proceeding further, ensure that we have "proper" state and not just a
-		// single stray event by looking for the create event.
-		hasCreate := false
-		for _, e := range events {
-			if e.Type == "m.room.create" && e.StateKey == "" {
-				hasCreate = true
-				break
+		if snapshotID == 0 {
+			// Ensure that we have "proper" state and not "stray" events from Synapse.
+			if err = ensureStateHasCreateEvent(events); err != nil {
+				return err
 			}
 		}
-		if !hasCreate {
-			const errMsg = "cannot create first snapshot without a create event"
-			sentry.WithScope(func(scope *sentry.Scope) {
-				scope.SetContext(internal.SentryCtxKey, map[string]interface{}{
-					"room_id":   roomID,
-					"len_state": len(events),
-				})
-				sentry.CaptureMessage(errMsg)
-			})
-			logger.Warn().
-				Str("room_id", roomID).
-				Int("len_state", len(events)).
-				Msg(errMsg)
-			// the HS gave us bad data so there's no point retrying => return DataError
-			return internal.NewDataError(errMsg)
-		}
 
-		// Insert the events.
-		eventIDToNID, err := a.eventsTable.Insert(txn, events, false)
+		// Insert the events and determine which ones are new.
+		newEventIDToNID, err := a.eventsTable.Insert(txn, events, false)
 		if err != nil {
 			return fmt.Errorf("failed to insert events: %w", err)
 		}
-		if len(eventIDToNID) == 0 {
-			// we don't have a current snapshot for this room but yet no events are new,
-			// no idea how this should be handled.
-			const errMsg = "Accumulator.Initialise: room has no current snapshot but also no new inserted events, doing nothing. This is probably a bug."
-			logger.Error().Str("room_id", roomID).Msg(errMsg)
-			sentry.CaptureException(fmt.Errorf(errMsg))
+		if len(newEventIDToNID) == 0 {
+			if snapshotID == 0 {
+				// we don't have a current snapshot for this room but yet no events are new,
+				// no idea how this should be handled.
+				const errMsg = "Accumulator.Initialise: room has no current snapshot but also no new inserted events, doing nothing. This is probably a bug."
+				logger.Error().Str("room_id", roomID).Msg(errMsg)
+				sentry.CaptureException(fmt.Errorf(errMsg))
+			}
+			// Otherwise we do have a current snapshot and there are no new events in
+			// the state block. We assume that the room state has not changed. (This
+			// could wrong if there was a state rollback or reset. But sync v2 doesn't
+			// communicate those, so there's no point trying to account for this.)
 			return nil
 		}
-
-		// pull out the event NIDs we just inserted
-		membershipEventIDs := make(map[string]struct{}, len(events))
+		newEvents := make([]Event, 0, len(newEventIDToNID))
 		for _, event := range events {
-			if event.Type == "m.room.member" {
-				membershipEventIDs[event.ID] = struct{}{}
-			}
-		}
-		memberNIDs := make([]int64, 0, len(eventIDToNID))
-		otherNIDs := make([]int64, 0, len(eventIDToNID))
-		for evID, nid := range eventIDToNID {
-			if _, exists := membershipEventIDs[evID]; exists {
-				memberNIDs = append(memberNIDs, int64(nid))
-			} else {
-				otherNIDs = append(otherNIDs, int64(nid))
+			newNid, isNew := newEventIDToNID[event.ID]
+			if isNew {
+				event.NID = newNid
+				newEvents = append(newEvents, event)
 			}
 		}
 
-		// Make a current snapshot
+		// Fetch the current state of the room.
+		var currentState stateMap
+		if snapshotID > 0 {
+			currentState, err = a.stateMapAtSnapshot(txn, snapshotID)
+			if err != nil {
+				return fmt.Errorf("failed to load state map: %w", err)
+			}
+		} else {
+			currentState = stateMap{
+				Memberships: make(map[string]int64, len(events)),
+				Other:       make(map[[2]string]int64, len(events)),
+			}
+		}
+		for _, ev := range newEvents {
+			currentState.Ingest(ev)
+		}
+		memberNIDs, otherNIDs := currentState.NIDs()
 		snapshot := &SnapshotRow{
 			RoomID:           roomID,
-			MembershipEvents: pq.Int64Array(memberNIDs),
-			OtherEvents:      pq.Int64Array(otherNIDs),
+			MembershipEvents: memberNIDs,
+			OtherEvents:      otherNIDs,
 		}
 		err = a.snapshotTable.Insert(txn, snapshot)
 		if err != nil {
@@ -649,4 +629,83 @@ func (a *Accumulator) filterToNewTimelineEvents(txn *sqlx.Tx, dedupedEvents []Ev
 	// B is seen event s[A,B,C] => s[1+1:] => [C]
 	// A is seen event s[A,B,C] => s[0+1:] => [B,C]
 	return dedupedEvents[seenIndex+1:], nil
+}
+
+func ensureStateHasCreateEvent(events []Event) error {
+	hasCreate := false
+	for _, e := range events {
+		if e.Type == "m.room.create" && e.StateKey == "" {
+			hasCreate = true
+			break
+		}
+	}
+	if !hasCreate {
+		const errMsg = "cannot create first snapshot without a create event"
+		sentry.WithScope(func(scope *sentry.Scope) {
+			scope.SetContext(internal.SentryCtxKey, map[string]interface{}{
+				"room_id":   events[0].RoomID,
+				"len_state": len(events),
+			})
+			sentry.CaptureMessage(errMsg)
+		})
+		logger.Warn().
+			Str("room_id", events[0].RoomID).
+			Int("len_state", len(events)).
+			Msg(errMsg)
+		// the HS gave us bad data so there's no point retrying => return DataError
+		return internal.NewDataError(errMsg)
+	}
+	return nil
+}
+
+type stateMap struct {
+	// state_key (user id) -> NID
+	Memberships map[string]int64
+	// type, state_key -> NID
+	Other map[[2]string]int64
+}
+
+func (s *stateMap) Ingest(e Event) (replacedNID int64) {
+	if e.Type == "m.room.member" {
+		replacedNID = s.Memberships[e.StateKey]
+		s.Memberships[e.StateKey] = e.NID
+	} else {
+		key := [2]string{e.Type, e.StateKey}
+		replacedNID = s.Other[key]
+		s.Other[key] = e.NID
+	}
+	return
+}
+
+func (s *stateMap) NIDs() (membershipNIDs, otherNIDs []int64) {
+	membershipNIDs = make([]int64, 0, len(s.Memberships))
+	otherNIDs = make([]int64, 0, len(s.Other))
+	for _, nid := range s.Memberships {
+		membershipNIDs = append(membershipNIDs, nid)
+	}
+	for _, nid := range s.Other {
+		otherNIDs = append(otherNIDs, nid)
+	}
+	return
+}
+
+func (a *Accumulator) stateMapAtSnapshot(txn *sqlx.Tx, snapID int64) (stateMap, error) {
+	snapshot, err := a.snapshotTable.Select(txn, snapID)
+	if err != nil {
+		return stateMap{}, err
+	}
+	// pull stripped events as this may be huge (think Matrix HQ)
+	events, err := a.eventsTable.SelectStrippedEventsByNIDs(txn, true, append(snapshot.MembershipEvents, snapshot.OtherEvents...))
+	if err != nil {
+		return stateMap{}, err
+	}
+
+	state := stateMap{
+		Memberships: make(map[string]int64, len(snapshot.MembershipEvents)),
+		Other:       make(map[[2]string]int64, len(snapshot.OtherEvents)),
+	}
+	for _, e := range events {
+		state.Ingest(e)
+	}
+	return state, nil
 }

--- a/state/accumulator.go
+++ b/state/accumulator.go
@@ -142,11 +142,6 @@ type InitialiseResult struct {
 	// SnapshotID is the ID of the snapshot which incorporates all added events.
 	// It has no meaning if AddedEvents is False.
 	SnapshotID int64
-	// PrependTimelineEvents is empty if the room was not initialised prior to this call.
-	// Otherwise, it is an order-preserving subset of the `state` argument to Initialise
-	// containing all events that were not persisted prior to the Initialise call. These
-	// should be prepended to the room timeline by the caller.
-	PrependTimelineEvents []json.RawMessage
 }
 
 // Initialise processes the state block of a V2 sync response for a particular room. If

--- a/state/accumulator_test.go
+++ b/state/accumulator_test.go
@@ -145,9 +145,9 @@ func TestAccumulatorInitialiseBadInputs(t *testing.T) {
 func TestAccumulatorAccumulate(t *testing.T) {
 	roomID := "!TestAccumulatorAccumulate:localhost"
 	roomEvents := []json.RawMessage{
-		[]byte(`{"event_id":"D", "type":"m.room.create", "state_key":"", "content":{"creator":"@me:localhost"}}`),
-		[]byte(`{"event_id":"E", "type":"m.room.member", "state_key":"@me:localhost", "content":{"membership":"join"}}`),
-		[]byte(`{"event_id":"F", "type":"m.room.join_rules", "state_key":"", "content":{"join_rule":"public"}}`),
+		[]byte(`{"event_id":"G", "type":"m.room.create", "state_key":"", "content":{"creator":"@me:localhost"}}`),
+		[]byte(`{"event_id":"H", "type":"m.room.member", "state_key":"@me:localhost", "content":{"membership":"join"}}`),
+		[]byte(`{"event_id":"I", "type":"m.room.join_rules", "state_key":"", "content":{"join_rule":"public"}}`),
 	}
 	db, close := connectToDB(t)
 	defer close()
@@ -160,11 +160,11 @@ func TestAccumulatorAccumulate(t *testing.T) {
 	// accumulate new state makes a new snapshot and removes the old snapshot
 	newEvents := []json.RawMessage{
 		// non-state event does nothing
-		[]byte(`{"event_id":"G", "type":"m.room.message","content":{"body":"Hello World","msgtype":"m.text"}}`),
+		[]byte(`{"event_id":"J", "type":"m.room.message","content":{"body":"Hello World","msgtype":"m.text"}}`),
 		// join_rules should clobber the one from initialise
-		[]byte(`{"event_id":"H", "type":"m.room.join_rules", "state_key":"", "content":{"join_rule":"public"}}`),
+		[]byte(`{"event_id":"K", "type":"m.room.join_rules", "state_key":"", "content":{"join_rule":"public"}}`),
 		// new state event should be added to the snapshot
-		[]byte(`{"event_id":"I", "type":"m.room.history_visibility", "state_key":"", "content":{"visibility":"public"}}`),
+		[]byte(`{"event_id":"L", "type":"m.room.history_visibility", "state_key":"", "content":{"visibility":"public"}}`),
 	}
 	var result AccumulateResult
 	err = sqlutil.WithTransaction(accumulator.db, func(txn *sqlx.Tx) error {

--- a/state/rooms_table.go
+++ b/state/rooms_table.go
@@ -40,6 +40,15 @@ func (t *RoomsTable) SelectRoomInfos(txn *sqlx.Tx) (infos []RoomInfo, err error)
 	return
 }
 
+func (t *RoomsTable) SelectRoomInfo(txn *sqlx.Tx, roomID string) (info RoomInfo, err error) {
+	err = txn.Get(&info, `
+		SELECT room_id, is_encrypted, upgraded_room_id, predecessor_room_id, type
+		FROM syncv3_rooms
+		WHERE room_id = $1
+	`, roomID)
+	return
+}
+
 func (t *RoomsTable) Upsert(txn *sqlx.Tx, info RoomInfo, snapshotID, latestNID int64) (err error) {
 	// This is a bit of a wonky query to ensure that you cannot set is_encrypted=false after it has been
 	// set to true.

--- a/sync2/handler2/handler.go
+++ b/sync2/handler2/handler.go
@@ -369,12 +369,12 @@ func (h *Handler) Accumulate(ctx context.Context, userID, deviceID, roomID strin
 	return nil
 }
 
-func (h *Handler) Initialise(ctx context.Context, roomID string, state []json.RawMessage) ([]json.RawMessage, error) {
+func (h *Handler) Initialise(ctx context.Context, roomID string, state []json.RawMessage) error {
 	res, err := h.Store.Initialise(roomID, state)
 	if err != nil {
 		logger.Err(err).Int("state", len(state)).Str("room", roomID).Msg("V2: failed to initialise room")
 		internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(err)
-		return nil, err
+		return err
 	}
 	if res.AddedEvents {
 		h.v2Pub.Notify(pubsub.ChanV2, &pubsub.V2Initialise{
@@ -382,7 +382,7 @@ func (h *Handler) Initialise(ctx context.Context, roomID string, state []json.Ra
 			SnapshotNID: res.SnapshotID,
 		})
 	}
-	return res.PrependTimelineEvents, nil
+	return nil
 }
 
 func (h *Handler) SetTyping(ctx context.Context, pollerID sync2.PollerID, roomID string, ephEvent json.RawMessage) {

--- a/sync2/handler2/handler.go
+++ b/sync2/handler2/handler.go
@@ -376,7 +376,11 @@ func (h *Handler) Initialise(ctx context.Context, roomID string, state []json.Ra
 		internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(err)
 		return err
 	}
-	if res.AddedEvents {
+	if res.ReplacedExistingSnapshot {
+		h.v2Pub.Notify(pubsub.ChanV2, &pubsub.V2InvalidateRoom{
+			RoomID: roomID,
+		})
+	} else if res.AddedEvents {
 		h.v2Pub.Notify(pubsub.ChanV2, &pubsub.V2Initialise{
 			RoomID:      roomID,
 			SnapshotNID: res.SnapshotID,

--- a/sync2/poller_test.go
+++ b/sync2/poller_test.go
@@ -770,8 +770,8 @@ func TestPollerResendsOnCallbackError(t *testing.T) {
 			// generate a receiver which errors for the right callback
 			generateReceiver: func() V2DataReceiver {
 				return &overrideDataReceiver{
-					initialise: func(ctx context.Context, roomID string, state []json.RawMessage) ([]json.RawMessage, error) {
-						return nil, fmt.Errorf("initialise error")
+					initialise: func(ctx context.Context, roomID string, state []json.RawMessage) error {
+						return fmt.Errorf("initialise error")
 					},
 				}
 			},
@@ -1210,7 +1210,7 @@ func (a *mockDataReceiver) Accumulate(ctx context.Context, userID, deviceID, roo
 	a.timelines[roomID] = append(a.timelines[roomID], timeline.Events...)
 	return nil
 }
-func (a *mockDataReceiver) Initialise(ctx context.Context, roomID string, state []json.RawMessage) ([]json.RawMessage, error) {
+func (a *mockDataReceiver) Initialise(ctx context.Context, roomID string, state []json.RawMessage) error {
 	a.states[roomID] = state
 	if a.incomingProcess != nil {
 		a.incomingProcess <- struct{}{}
@@ -1220,7 +1220,7 @@ func (a *mockDataReceiver) Initialise(ctx context.Context, roomID string, state 
 	}
 	// The return value is a list of unknown state events to be prepended to the room
 	// timeline. Untested here---return nil for now.
-	return nil, nil
+	return nil
 }
 func (s *mockDataReceiver) UpdateDeviceSince(ctx context.Context, userID, deviceID, since string) {
 	s.mu.Lock()
@@ -1233,7 +1233,7 @@ func (s *mockDataReceiver) UpdateDeviceSince(ctx context.Context, userID, device
 
 type overrideDataReceiver struct {
 	accumulate          func(ctx context.Context, userID, deviceID, roomID, prevBatch string, timeline []json.RawMessage) error
-	initialise          func(ctx context.Context, roomID string, state []json.RawMessage) ([]json.RawMessage, error)
+	initialise          func(ctx context.Context, roomID string, state []json.RawMessage) error
 	setTyping           func(ctx context.Context, pollerID PollerID, roomID string, ephEvent json.RawMessage)
 	updateDeviceSince   func(ctx context.Context, userID, deviceID, since string)
 	addToDeviceMessages func(ctx context.Context, userID, deviceID string, msgs []json.RawMessage) error
@@ -1253,9 +1253,9 @@ func (s *overrideDataReceiver) Accumulate(ctx context.Context, userID, deviceID,
 	}
 	return s.accumulate(ctx, userID, deviceID, roomID, timeline.PrevBatch, timeline.Events)
 }
-func (s *overrideDataReceiver) Initialise(ctx context.Context, roomID string, state []json.RawMessage) ([]json.RawMessage, error) {
+func (s *overrideDataReceiver) Initialise(ctx context.Context, roomID string, state []json.RawMessage) error {
 	if s.initialise == nil {
-		return nil, nil
+		return nil
 	}
 	return s.initialise(ctx, roomID, state)
 }

--- a/sync3/caches/update.go
+++ b/sync3/caches/update.go
@@ -18,6 +18,14 @@ type RoomUpdate interface {
 	UserRoomMetadata() *UserRoomData
 }
 
+type RoomCacheInvalidationUpdate struct {
+	RoomUpdate
+}
+
+func (u *RoomCacheInvalidationUpdate) Type() string {
+	return fmt.Sprintf("RoomCacheInvalidationUpdate[%s]", u.RoomID())
+}
+
 // RoomEventUpdate corresponds to a single event seen in a joined room's timeline under sync v2.
 type RoomEventUpdate struct {
 	RoomUpdate

--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -761,9 +761,17 @@ func (u *UserCache) ShouldIgnore(userID string) bool {
 	return ignored
 }
 
-func (u *UserCache) OnInvalidateRoom(ctx context.Context, roomID string) {
+func (u *UserCache) OnInvalidateRoom(ctx context.Context, metadata *internal.RoomMetadata) {
+	urd := u.LoadRoomData(metadata.RoomID)
 	// Nothing for now. In UserRoomData the fields dependant on room state are
 	// IsDM, IsInvite, HasLeft, Invite, CanonicalisedName, ResolvedAvatarURL, Spaces.
 	// Not clear to me if we need to reload these or if we will inherit any changes from
 	// the global cache.
+	u.emitOnRoomUpdate(ctx, &RoomCacheInvalidationUpdate{
+		RoomUpdate: &roomUpdateCache{
+			roomID:         metadata.RoomID,
+			globalRoomData: metadata,
+			userRoomData:   &urd,
+		},
+	})
 }

--- a/sync3/dispatcher.go
+++ b/sync3/dispatcher.go
@@ -287,7 +287,7 @@ func (d *Dispatcher) notifyListeners(ctx context.Context, ed *caches.EventData, 
 	}
 }
 
-func (d *Dispatcher) OnInvalidateRoom(ctx context.Context, roomID string) {
+func (d *Dispatcher) OnInvalidateRoom(ctx context.Context, roomID string, joined, invited []string) {
 	// First dispatch to the global cache.
 	receiver, ok := d.userToReceiver[DispatcherAllUsers]
 	if !ok {
@@ -295,7 +295,10 @@ func (d *Dispatcher) OnInvalidateRoom(ctx context.Context, roomID string) {
 	}
 	receiver.OnInvalidateRoom(ctx, roomID)
 
+	d.jrt.ReloadMembershipsForRoom(roomID, joined, invited)
+
 	// Then dispatch to any users who are joined to that room.
+	// XXX: the caller has to update the JoinedRoomTracker before calling this function
 	joinedUsers, _ := d.jrt.JoinedUsersForRoom(roomID, nil)
 	d.userToReceiverMu.RLock()
 	defer d.userToReceiverMu.RUnlock()

--- a/sync3/dispatcher.go
+++ b/sync3/dispatcher.go
@@ -296,7 +296,11 @@ func (d *Dispatcher) OnInvalidateRoom(ctx context.Context, metadata *internal.Ro
 
 	pokeUsers := func(users []string) {
 		for _, userID := range users {
-			uc := d.userToReceiver[userID].(*caches.UserCache)
+			rec := d.userToReceiver[userID]
+			if rec == nil {
+				continue
+			}
+			uc := rec.(*caches.UserCache)
 			if uc != nil {
 				uc.OnInvalidateRoom(ctx, metadata)
 			}

--- a/sync3/handler/handler.go
+++ b/sync3/handler/handler.go
@@ -807,7 +807,7 @@ func (h *SyncLiveHandler) OnInvalidateRoom(p *pubsub.V2InvalidateRoom) {
 	ctx, task := internal.StartTask(context.Background(), "OnInvalidateRoom")
 	defer task.End()
 
-	joined, invited, err := fetchJoinedAndInvited(h.Storage.DB, p.RoomID)
+	joined, invited, err := h.Storage.FetchJoinedAndInvited(p.RoomID)
 	if err != nil {
 		hub := internal.GetSentryHubFromContextOrDefault(ctx)
 		hub.WithScope(func(scope *sentry.Scope) {
@@ -822,44 +822,6 @@ func (h *SyncLiveHandler) OnInvalidateRoom(p *pubsub.V2InvalidateRoom) {
 	}
 
 	h.Dispatcher.OnInvalidateRoom(ctx, p.RoomID, joined, invited)
-}
-
-// TODO: move this to Storage
-func fetchJoinedAndInvited(db *sqlx.DB, roomID string) (joined, invited []string, err error) {
-	var memberships []struct {
-		UserID     string `db:"state_key"`
-		Membership string `db:"membership"`
-	}
-	err = db.Select(&memberships, `
-	WITH snapshot(membership_nids) AS (
-        SELECT membership_events
-        FROM syncv3_snapshots
-            JOIN syncv3_rooms ON snapshot_id = current_snapshot_id
-        WHERE syncv3_rooms.room_id = $1
-	)
-	SELECT state_key, membership
-	FROM syncv3_events JOIN snapshot ON (
-		event_nid = ANY( membership_nids )
-	)
-	WHERE membership IN ('join', '_join', 'invite', '_invite')
-	`, roomID)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	for _, membership := range memberships {
-		switch membership.Membership {
-		case "_join":
-			fallthrough
-		case "join":
-			joined = append(joined, membership.UserID)
-		case "_invite":
-			fallthrough
-		case "invite":
-			invited = append(invited, membership.UserID)
-		}
-	}
-	return
 }
 
 func parseIntFromQuery(u *url.URL, param string) (result int64, err *internal.HandlerError) {

--- a/sync3/handler/handler.go
+++ b/sync3/handler/handler.go
@@ -807,6 +807,7 @@ func (h *SyncLiveHandler) OnInvalidateRoom(p *pubsub.V2InvalidateRoom) {
 	ctx, task := internal.StartTask(context.Background(), "OnInvalidateRoom")
 	defer task.End()
 
+	// TODO: the only consumer actually wants a set---could make this return a set directly?
 	joined, invited, err := h.Storage.FetchJoinedAndInvited(p.RoomID)
 	if err != nil {
 		hub := internal.GetSentryHubFromContextOrDefault(ctx)

--- a/sync3/tracker.go
+++ b/sync3/tracker.go
@@ -184,3 +184,29 @@ func (t *JoinedRoomsTracker) NumInvitedUsersForRoom(roomID string) int {
 	defer t.mu.RUnlock()
 	return len(t.roomIDToInvitedUsers[roomID])
 }
+
+func (t *JoinedRoomsTracker) ReloadMembershipsForRoom(roomID string, joined, invited []string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	for _, userID := range joined {
+		addToSet(t.roomIDToJoinedUsers, roomID, userID)
+		addToSet(t.userIDToJoinedRooms, userID, roomID)
+		delete(t.roomIDToInvitedUsers[roomID], userID)
+	}
+
+	for _, userID := range invited {
+		delete(t.roomIDToJoinedUsers[roomID], userID)
+		delete(t.userIDToJoinedRooms[userID], roomID)
+		addToSet(t.roomIDToInvitedUsers, roomID, userID)
+	}
+}
+
+func addToSet(mapOfSets map[string]set, key string, element string) {
+	s, exists := mapOfSets[key]
+	if !exists {
+		s = make(set)
+		mapOfSets[key] = make(set)
+	}
+	s[element] = struct{}{}
+}

--- a/sync3/tracker.go
+++ b/sync3/tracker.go
@@ -199,7 +199,6 @@ func (t *JoinedRoomsTracker) ReloadMembershipsForRoom(roomID string, joined, inv
 	}
 
 	t.mu.Lock()
-	defer t.mu.Unlock()
 
 	// 1. Overwrite the room's memberships with the given arguments.
 	oldJoined := t.roomIDToJoinedUsers[roomID]
@@ -228,6 +227,8 @@ func (t *JoinedRoomsTracker) ReloadMembershipsForRoom(roomID string, joined, inv
 			}
 		}
 	}
+
+	t.mu.Unlock()
 
 	// 4. Scan the old invited list for users who have left.
 	for userID := range oldInvited {

--- a/tests-e2e/gappy_state_test.go
+++ b/tests-e2e/gappy_state_test.go
@@ -1,6 +1,7 @@
 package syncv3_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/matrix-org/sliding-sync/sync3"
 	"github.com/matrix-org/sliding-sync/testutils/m"
@@ -59,10 +60,17 @@ func TestGappyState(t *testing.T) {
 	nameContent := map[string]interface{}{"name": "potato"}
 	alice.SetState(t, roomID, "m.room.name", "", nameContent)
 
-	t.Log("Alice sends lots of message events (more than the poller will request in a timeline.")
-	var latestMessageID string
-	for i := 0; i < 51; i++ {
-		latestMessageID = alice.SendEventUnsynced(t, roomID, Event{
+	t.Log("Alice sends lots of other state events.")
+	const numOtherState = 40
+	for i := 0; i < numOtherState; i++ {
+		alice.SetState(t, roomID, "com.example.dummy", fmt.Sprintf("%d", i), map[string]any{})
+	}
+
+	t.Log("Alice sends a batch of message events.")
+	const numMessages = 20
+	var lastMsgID string
+	for i := 0; i < numMessages; i++ {
+		lastMsgID = alice.SendEventUnsynced(t, roomID, Event{
 			Type: "m.room.message",
 			Content: map[string]interface{}{
 				"msgtype": "m.text",
@@ -71,28 +79,50 @@ func TestGappyState(t *testing.T) {
 		})
 	}
 
-	t.Log("Alice requests an initial sliding sync on device 2.")
+	t.Logf("The proxy is now %d events behind the HS, which should trigger a limited sync", 1+numOtherState+numMessages)
+
+	t.Log("Alice requests an initial sliding sync on device 2, with timeline limit big enough to see her first message at the start of the test.")
 	syncResp = alice.SlidingSync(t,
 		sync3.Request{
 			Lists: map[string]sync3.RequestList{
 				"a": {
 					Ranges: [][2]int64{{0, 20}},
 					RoomSubscription: sync3.RoomSubscription{
-						TimelineLimit: 10,
+						TimelineLimit: 100,
 					},
 				},
 			},
 		},
 	)
 
-	t.Log("She should see her latest message with the room name updated")
+	// We're testing here that the state events from the gappy poll are NOT injected
+	// into the timeline. The poll is only going to use timeline limit 1 because it's
+	// the first poll on a new device. See integration test for a "proper" gappy poll.
+	t.Log("She should see the updated room name, her most recent message, but NOT the state events in the gap nor messages from before the gap.")
 	m.MatchResponse(
 		t,
 		syncResp,
 		m.MatchRoomSubscription(
 			roomID,
 			m.MatchRoomName("potato"),
-			MatchRoomTimelineMostRecent(1, []Event{{ID: latestMessageID}}),
+			MatchRoomTimelineMostRecent(1, []Event{{ID: lastMsgID}}),
+			func(r sync3.Room) error {
+				for _, rawEv := range r.Timeline {
+					var ev Event
+					err := json.Unmarshal(rawEv, &ev)
+					if err != nil {
+						t.Fatal(err)
+					}
+					// Shouldn't see the state events, only messages
+					if ev.Type != "m.room.message" {
+						return fmt.Errorf("timeline contained event %s of type %s (expected m.room.message)", ev.ID, ev.Type)
+					}
+					if ev.ID == firstMessageID {
+						return fmt.Errorf("timeline contained first message from before the gap")
+					}
+				}
+				return nil
+			},
 		),
 	)
 }

--- a/tests-integration/v3_test.go
+++ b/tests-integration/v3_test.go
@@ -42,6 +42,8 @@ const (
 	aliceToken = "ALICE_BEARER_TOKEN"
 	bob        = "@bob:localhost"
 	bobToken   = "BOB_BEARER_TOKEN"
+	chris      = "@chris:localhost"
+	chrisToken = "CHRIS_BEARER_TOKEN"
 )
 
 var (


### PR DESCRIPTION
Primarily a perf fix for when the proxy re-joins a room, but it's also arguably a correctness fix because we have no idea how these things appear in the timeline.