### PR TITLE
Return a dummy /versions response in tests

### DIFF
--- a/tests-integration/v3_test.go
+++ b/tests-integration/v3_test.go
@@ -243,6 +243,10 @@ func runTestV2Server(t testutils.TestBenchInterface) *testV2Server {
 		timeToWaitForV2Response: time.Second,
 	}
 	r := mux.NewRouter()
+	r.HandleFunc("/_matrix/client/versions", func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(`{"versions": ["v1.1"]}`))
+	})
 	r.HandleFunc("/_matrix/client/r0/account/whoami", func(w http.ResponseWriter, req *http.Request) {
 		token := strings.TrimPrefix(req.Header.Get("Authorization"), "Bearer ")
 		userID := server.userID(token)


### PR DESCRIPTION
Otherwise every integration test logs a warning that isn't useful, since #286:

```
=== RUN   TestBackfillInviteDoesntCorruptState
Note: tests require a postgres install accessible to the current user
createdb: error: database creation failed: ERROR:  database "syncv3_test" already exists
12:29:34 WRN Could not contact upstream homeserver. Is SYNCV3_SERVER set correctly? error="/versions returned HTTP 404" dest=http://127.0.0.1:45461
```
