### PR TITLE
Remove temporary metric

### DIFF
--- a/state/accumulator.go
+++ b/state/accumulator.go
@@ -4,9 +4,9 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+
 	"github.com/matrix-org/sliding-sync/internal"
 	"github.com/matrix-org/sliding-sync/sync2"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/getsentry/sentry-go"
 
@@ -23,13 +23,12 @@ import (
 // Accumulate function for timeline events. v2 sync must be called with a large enough timeline.limit
 // for this to work!
 type Accumulator struct {
-	db                     *sqlx.DB
-	roomsTable             *RoomsTable
-	eventsTable            *EventTable
-	snapshotTable          *SnapshotTable
-	spacesTable            *SpacesTable
-	entityName             string
-	snapshotMemberCountVec *prometheus.HistogramVec // TODO: Remove, this is temporary to get a feeling how often a new snapshot is created
+	db            *sqlx.DB
+	roomsTable    *RoomsTable
+	eventsTable   *EventTable
+	snapshotTable *SnapshotTable
+	spacesTable   *SpacesTable
+	entityName    string
 }
 
 func NewAccumulator(db *sqlx.DB) *Accumulator {
@@ -283,10 +282,6 @@ func (a *Accumulator) Initialise(roomID string, state []json.RawMessage) (Initia
 		if err != nil {
 			return fmt.Errorf("failed to insert snapshot: %w", err)
 		}
-		if a.snapshotMemberCountVec != nil {
-			logger.Trace().Str("room_id", roomID).Int("members", len(memberNIDs)).Msg("Inserted new snapshot")
-			a.snapshotMemberCountVec.WithLabelValues(roomID).Observe(float64(len(memberNIDs)))
-		}
 		res.AddedEvents = true
 		latestNID := int64(0)
 		for _, nid := range otherNIDs {
@@ -518,10 +513,6 @@ func (a *Accumulator) Accumulate(txn *sqlx.Tx, userID, roomID string, timeline s
 			}
 			if err = a.snapshotTable.Insert(txn, newSnapshot); err != nil {
 				return AccumulateResult{}, fmt.Errorf("failed to insert new snapshot: %w", err)
-			}
-			if a.snapshotMemberCountVec != nil {
-				logger.Trace().Str("room_id", roomID).Int("members", len(memNIDs)).Msg("Inserted new snapshot")
-				a.snapshotMemberCountVec.WithLabelValues(roomID).Observe(float64(len(memNIDs)))
 			}
 			snapID = newSnapshot.SnapshotID
 		}

--- a/state/storage.go
+++ b/state/storage.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/matrix-org/sliding-sync/sync2"
 	"os"
 	"strings"
 
+	"github.com/matrix-org/sliding-sync/sync2"
+
 	"github.com/getsentry/sentry-go"
 	"github.com/lib/pq"
-	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/matrix-org/sliding-sync/internal"
@@ -86,17 +86,6 @@ func NewStorageWithDB(db *sqlx.DB, addPrometheusMetrics bool) *Storage {
 		snapshotTable: NewSnapshotsTable(db),
 		spacesTable:   NewSpacesTable(db),
 		entityName:    "server",
-	}
-
-	if addPrometheusMetrics {
-		acc.snapshotMemberCountVec = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: "sliding_sync",
-			Subsystem: "poller",
-			Name:      "snapshot_size",
-			Help:      "Number of membership events in a snapshot",
-			Buckets:   []float64{100.0, 500.0, 1000.0, 5000.0, 10000.0, 20000.0, 50000.0, 100000.0, 150000.0},
-		}, []string{"room_id"})
-		prometheus.MustRegister(acc.snapshotMemberCountVec)
 	}
 
 	return &Storage{
@@ -1046,9 +1035,6 @@ func (s *Storage) Teardown() {
 	err := s.Accumulator.db.Close()
 	if err != nil {
 		panic("Storage.Teardown: " + err.Error())
-	}
-	if s.Accumulator.snapshotMemberCountVec != nil {
-		prometheus.Unregister(s.Accumulator.snapshotMemberCountVec)
 	}
 }
 


### PR DESCRIPTION
This can cause issues on large instances where it causes the /metrics response size to exceed the `-promscrape.maxScrapeSize`.

