### PR TITLE
Remove `RequestedLatestEvents` field from `UserRoomData`

### DIFF
--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -347,6 +347,21 @@ func (c *UserCache) LoadRoomData(roomID string) UserRoomData {
 	return data
 }
 
+// LoadRooms is a batch version of LoadRoomData. Returns a map keyed by roomID.
+func (c *UserCache) LoadRooms(roomIDs ...string) map[string]UserRoomData {
+	result := make(map[string]UserRoomData, len(roomIDs))
+	c.roomToDataMu.RLock()
+	defer c.roomToDataMu.RUnlock()
+	for _, roomID := range roomIDs {
+		data, ok := c.roomToData[roomID]
+		if !ok {
+			data = NewUserRoomData()
+		}
+		result[roomID] = data
+	}
+	return result
+}
+
 type roomUpdateCache struct {
 	roomID string
 	// globalRoomData is a snapshot of the global metadata for this room immediately

--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -42,10 +42,6 @@ type UserRoomData struct {
 	HighlightCount    int
 	Invite            *InviteData
 
-	// this field is set by LazyLoadTimelines and is per-function call, and is not persisted in-memory.
-	// The zero value of this safe to use (0 latest nid, no prev batch, no timeline).
-	RequestedLatestEvents state.LatestEvents
-
 	// TODO: should CanonicalisedName really be in RoomConMetadata? It's only set in SetRoom AFAICS
 	CanonicalisedName string // stripped leading symbols like #, all in lower case
 	// Set of spaces this room is a part of, from the perspective of this user. This is NOT global room data

--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -554,7 +554,6 @@ func (s *ConnState) lazyLoadTypingMembers(ctx context.Context, response *sync3.R
 func (s *ConnState) getInitialRoomData(ctx context.Context, roomSub sync3.RoomSubscription, bumpEventTypes []string, roomIDs ...string) map[string]sync3.Room {
 	ctx, span := internal.StartSpan(ctx, "getInitialRoomData")
 	defer span.End()
-	rooms := make(map[string]sync3.Room, len(roomIDs))
 	// We want to grab the user room data and the room metadata for each room ID. We use the globally
 	// highest NID we've seen to act as an anchor for the request. This anchor does not guarantee that
 	// events returned here have already been seen - the position is not globally ordered - so because
@@ -610,6 +609,8 @@ func (s *ConnState) getInitialRoomData(ctx context.Context, roomSub sync3.RoomSu
 	if roomIDToState == nil { // e.g no required_state
 		roomIDToState = make(map[string][]json.RawMessage)
 	}
+
+	rooms := make(map[string]sync3.Room, len(roomIDs))
 	for _, roomID := range roomIDs {
 		userRoomData, ok := roomIDToUserRoomData[roomID]
 		if !ok {

--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -566,17 +566,11 @@ func (s *ConnState) getInitialRoomData(ctx context.Context, roomSub sync3.RoomSu
 	roomToUsersInTimeline := make(map[string][]string, len(roomIDToUserRoomData))
 	roomToTimeline := make(map[string][]json.RawMessage)
 	for roomID, urd := range roomIDToUserRoomData {
-		set := make(map[string]struct{})
+		senders := make(map[string]struct{})
 		for _, ev := range urd.RequestedLatestEvents.Timeline {
-			set[gjson.GetBytes(ev, "sender").Str] = struct{}{}
+			senders[gjson.GetBytes(ev, "sender").Str] = struct{}{}
 		}
-		userIDs := make([]string, len(set))
-		i := 0
-		for userID := range set {
-			userIDs[i] = userID
-			i++
-		}
-		roomToUsersInTimeline[roomID] = userIDs
+		roomToUsersInTimeline[roomID] = keys(senders)
 		roomToTimeline[roomID] = urd.RequestedLatestEvents.Timeline
 		// remember what we just loaded so if we see these events down the live stream we know to ignore them.
 		// This means that requesting a direct room subscription causes the connection to jump ahead to whatever

--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -777,7 +777,7 @@ func clampSliceRangeToListSize(ctx context.Context, r [2]int64, totalRooms int64
 	}
 }
 
-// Returns a slice containing copies of the keys of the given map, in no particular
+// keys returns a slice containing copies of the keys of the given map, in no particular
 // order.
 func keys[K comparable, V any](m map[K]V) []K {
 	if m == nil {


### PR DESCRIPTION
Helps with the sort of confusion I had complained about in https://github.com/matrix-org/sliding-sync/issues/46.

My goal here is to make the UserRoomData type contain exactly the data that the UserCache is responsible for maintaining. This is step 1 of N, for some integer N > 1.