### PR TITLE
Cleanup invites in the poller, not the API

### DIFF
--- a/state/accumulator.go
+++ b/state/accumulator.go
@@ -28,6 +28,7 @@ type Accumulator struct {
 	eventsTable   *EventTable
 	snapshotTable *SnapshotTable
 	spacesTable   *SpacesTable
+	invitesTable  *InvitesTable
 	entityName    string
 }
 
@@ -38,6 +39,7 @@ func NewAccumulator(db *sqlx.DB) *Accumulator {
 		eventsTable:   NewEventTable(db),
 		snapshotTable: NewSnapshotsTable(db),
 		spacesTable:   NewSpacesTable(db),
+		invitesTable:  NewInvitesTable(db),
 		entityName:    "server",
 	}
 }

--- a/state/accumulator.go
+++ b/state/accumulator.go
@@ -297,6 +297,10 @@ func (a *Accumulator) Initialise(roomID string, state []json.RawMessage) (Initia
 			}
 		}
 
+		if err = a.invitesTable.RemoveSupersededInvites(txn, roomID, events); err != nil {
+			return fmt.Errorf("RemoveSupersededInvites: %w", err)
+		}
+
 		if err = a.spacesTable.HandleSpaceUpdates(txn, events); err != nil {
 			return fmt.Errorf("HandleSpaceUpdates: %s", err)
 		}
@@ -543,6 +547,10 @@ func (a *Accumulator) Accumulate(txn *sqlx.Tx, userID, roomID string, timeline s
 			return AccumulateResult{}, err
 		}
 		result.RequiresReload = currentStateRedactions > 0
+	}
+
+	if err = a.invitesTable.RemoveSupersededInvites(txn, roomID, postInsertEvents); err != nil {
+		return AccumulateResult{}, fmt.Errorf("RemoveSupersededInvites: %w", err)
 	}
 
 	if err = a.spacesTable.HandleSpaceUpdates(txn, postInsertEvents); err != nil {

--- a/state/invites_table.go
+++ b/state/invites_table.go
@@ -3,6 +3,7 @@ package state
 import (
 	"database/sql"
 	"encoding/json"
+	"github.com/lib/pq"
 
 	"github.com/jmoiron/sqlx"
 )
@@ -14,14 +15,17 @@ import (
 //     correctly when the user joined the room.
 //   - The user could read room data in the room without being joined to the room e.g could pull
 //     `required_state` and `timeline` as they would be authorised by the invite to see this data.
+//
 // Instead, we now completely split out invites from the normal event flow. This fixes the issues
 // outlined above but introduce more problems:
 //   - How do you sort the invite with rooms?
 //   - How do you calculate the room name when you lack heroes?
+//
 // For now, we say that invites:
 //   - are treated as a highlightable event for the purposes of sorting by highlight count.
 //   - are given the timestamp of when the invite arrived.
 //   - calculate the room name on a best-effort basis given the lack of heroes (same as element-web).
+//
 // When an invite is rejected, it appears in the `leave` section which then causes the invite to be
 // removed from this table.
 type InvitesTable struct {
@@ -44,6 +48,40 @@ func NewInvitesTable(db *sqlx.DB) *InvitesTable {
 
 func (t *InvitesTable) RemoveInvite(userID, roomID string) error {
 	_, err := t.db.Exec(`DELETE FROM syncv3_invites WHERE user_id = $1 AND room_id = $2`, userID, roomID)
+	return err
+}
+
+// RemoveSupersededInvites accepts a list of events in the given room. The events should
+// either
+//   - contain at most one membership event per user, or else
+//   - be in timeline order (most recent last)
+//
+// (corresponding to an Accumulate and an Initialise call, respectively).
+//
+// The events are scanned in order for membership changes, to determine the "final"
+// memberships. Users who final membership is not "invite" have their outstanding
+// invites to this room deleted.
+func (t *InvitesTable) RemoveSupersededInvites(txn *sqlx.Tx, roomID string, newEvents []Event) error {
+	memberships := map[string]string{} // user ID -> memberships
+	for _, ev := range newEvents {
+		if ev.Type != "m.room.member" {
+			continue
+		}
+		memberships[ev.StateKey] = ev.Membership
+	}
+
+	var usersToRemove []string
+	for userID, membership := range memberships {
+		if membership != "invite" && membership != "_invite" {
+			usersToRemove = append(usersToRemove, userID)
+		}
+	}
+
+	_, err := txn.Exec(`
+		DELETE FROM syncv3_invites
+		WHERE user_id = ANY($1) AND room_id = $2
+	`, pq.StringArray(usersToRemove), roomID)
+
 	return err
 }
 

--- a/state/invites_table.go
+++ b/state/invites_table.go
@@ -77,6 +77,10 @@ func (t *InvitesTable) RemoveSupersededInvites(txn *sqlx.Tx, roomID string, newE
 		}
 	}
 
+	if len(usersToRemove) == 0 {
+		return nil
+	}
+
 	_, err := txn.Exec(`
 		DELETE FROM syncv3_invites
 		WHERE user_id = ANY($1) AND room_id = $2

--- a/state/storage.go
+++ b/state/storage.go
@@ -85,6 +85,7 @@ func NewStorageWithDB(db *sqlx.DB, addPrometheusMetrics bool) *Storage {
 		eventsTable:   NewEventTable(db),
 		snapshotTable: NewSnapshotsTable(db),
 		spacesTable:   NewSpacesTable(db),
+		invitesTable:  NewInvitesTable(db),
 		entityName:    "server",
 	}
 
@@ -94,7 +95,7 @@ func NewStorageWithDB(db *sqlx.DB, addPrometheusMetrics bool) *Storage {
 		UnreadTable:       NewUnreadTable(db),
 		EventsTable:       acc.eventsTable,
 		AccountDataTable:  NewAccountDataTable(db),
-		InvitesTable:      NewInvitesTable(db),
+		InvitesTable:      acc.invitesTable,
 		TransactionsTable: NewTransactionsTable(db),
 		DeviceDataTable:   NewDeviceDataTable(db),
 		ReceiptTable:      NewReceiptTable(db),

--- a/sync3/caches/global.go
+++ b/sync3/caches/global.go
@@ -345,15 +345,6 @@ func (c *GlobalCache) OnNewEvent(
 					// remove this user as a hero
 					metadata.RemoveHero(*ed.StateKey)
 				}
-
-				if membership == "join" && eventJSON.Get("unsigned.prev_content.membership").Str == "invite" {
-					// invite -> join, retire any outstanding invites
-					err := c.store.InvitesTable.RemoveInvite(*ed.StateKey, ed.RoomID)
-					if err != nil {
-						logger.Err(err).Str("user", *ed.StateKey).Str("room", ed.RoomID).Msg("failed to remove accepted invite")
-						internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(err)
-					}
-				}
 			}
 			if len(metadata.Heroes) < 6 && (membership == "join" || membership == "invite") {
 				// try to find the existing hero e.g they changed their display name


### PR DESCRIPTION
Kegan and I were surprised to see the API side of the proxy doing this.

I removed the existing logic and saw that TestStuckInvites broke. Hopefully it should pass after these changes. Does that count as sufficient testing?