### PR TITLE
Build and attach {amd,arm}64 binaries to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        os: ["linux"]
         arch: ["amd64", "arm64"]
     steps:
       - uses: actions/checkout@v4
@@ -18,6 +19,7 @@ jobs:
       - run: mkdir build
       - run: go build -o build/syncv3_linux_${{ matrix.arch }} ./cmd/syncv3
         env:
+          GOOS: ${{ matrix.os }}
           GOARCH: ${{ matrix.arch }}
       - uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: "Build and attach binary to release"
+on:
+  release:
+    types: ["created"]
+permissions:
+  contents: write  # to upload the binaries to the release
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ["amd64", "arm64"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: "1.20"
+      - run: mkdir build
+      - run: go build ./cmd/syncv3 -o build/syncv3_linux_${{ matrix.arch }}
+        env:
+          GOARCH: ${{ matrix.arch }}
+      - uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+        with:
+          files: build/syncv3_linux_${{ matrix.arch }}
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           go-version: "1.20"
       - run: mkdir build
-      - run: go build ./cmd/syncv3 -o build/syncv3_linux_${{ matrix.arch }}
+      - run: go build -o build/syncv3_linux_${{ matrix.arch }} ./cmd/syncv3
         env:
           GOARCH: ${{ matrix.arch }}
       - uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1


### PR DESCRIPTION
Completely untested. Cribbed a little [from Synapse's CI](https://github.com/matrix-org/synapse/blob/139a24de9ee0e81faece1e375a197123a6e10b67/.github/workflows/release-artifacts.yml#L186-L212) but kept simple.

I suggest 
1. we commit this to main
2. I create a draft release pointing at main
3. We check the CI runs
4. If anything breaks, discard the release, fix and return to (1)
5. ???
6. Profit

I also ran this through https://github.com/rhysd/actionlint which reported no complaints.

Fixes #334.

