### PR TITLE
Make the docker build trigger on `v*` tags too.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,8 +5,7 @@ name: "Docker"
 on:
   push:
     branches: ["main"]
-  release: # A GitHub release was published
-    types: [published]
+    tags: ["v*"]
   workflow_dispatch: # A build was manually requested
   workflow_call: # Another pipeline called us
 
@@ -50,7 +49,7 @@ jobs:
             ghcr.io/${{ env.GHCR_NAMESPACE }}/sliding-sync:main
 
       - name: Build release Sliding Sync image
-        if: github.event_name == 'release' # Only for GitHub releases
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         id: docker_build_sliding_sync_release
         uses: docker/build-push-action@v4
         with:
@@ -61,7 +60,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ env.GHCR_NAMESPACE }}/sliding-sync:latest
-            ghcr.io/${{ env.GHCR_NAMESPACE }}/sliding-sync:${{ github.event.release.tag_name }}
+            ghcr.io/${{ env.GHCR_NAMESPACE }}/sliding-sync:${{ github.ref_name }}
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,13 @@
 0. Ensure that CI passes against the commit you want to release.
 1. Tag that release. The tag name should start with `v`. Push it to GitHub.
-2. GitHub should see tag and trigger [a GHA workflow](https://github.com/matrix-org/sliding-sync/actions/workflows/release.yml). It should: 
-   - build binaries,
-   - create a draft release for this tag, and
+2. After the tag is pushed, Github will see the tag and trigger [a GHA workflow](https://github.com/matrix-org/sliding-sync/actions/workflows/docker.yml). It should
+   - build docker images,
+   - publish them to [the project's container repository](https://github.com/matrix-org/sliding-sync/pkgs/container/sliding-sync),
+   - and also run some [third-party vulnerability scanner](https://github.com/matrix-org/sliding-sync/blob/97b21d4d9ea2c151ac5535a46ad9930c5a2a7f32/.github/workflows/docker.yml#L66-L76), for some reason.
+3. GitHub should also trigger [a second GHA workflow](https://github.com/matrix-org/sliding-sync/actions/workflows/release.yml), which: 
+   - builds binaries,
+   - creates a draft release for this tag, and
    - uploads the binaries as artifacts to this release.
-3. Go to https://github.com/matrix-org/sliding-sync/releases/ to find your release. Check that the binaries are attached successfully. Write release notes. When you're happy, publish.
+4. Go to https://github.com/matrix-org/sliding-sync/releases/ to find your release. **Edit it in place** (do not create a new release). Check that the binaries are attached successfully. Write release notes. When you're happy, publish.
+
+That's it. Relax, take a deep breath, pat yourself on the back, then move on with your life.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,6 +8,11 @@
    - builds binaries,
    - creates a draft release for this tag, and
    - uploads the binaries as artifacts to this release.
-4. Go to https://github.com/matrix-org/sliding-sync/releases/ to find your release. **Edit it in place** (do not create a new release). Check that the binaries are attached successfully. Write release notes. When you're happy, publish.
+4. Go to https://github.com/matrix-org/sliding-sync/releases/ to find your release. 
+   - **Edit it in place** (do not create a new release).
+   - Check that the binaries are attached successfully.
+   - Write release notes.
+   - Wait for the docker build to finish. This takes ~10 minutes; check the GHA workflow and the (check [packages repo](https://github.com/matrix-org/sliding-sync/pkgs/container/sliding-sync)).
+   - Publish when you're happy with the release notes.
 
 That's it. Relax, take a deep breath, pat yourself on the back, then move on with your life.


### PR DESCRIPTION
Together with the changes in #339 and fixups, this means that releasing is a case of
- tag commit starting with v
- push tag
- draft release notes
- publish

Proof: I tagged 1e63d8d as v0.99.11-ghatest5. Then https://github.com/matrix-org/sliding-sync/actions/runs/6484915911 ran and https://github.com/matrix-org/sliding-sync/pkgs/container/sliding-sync/136458534?tag=v0.99.11-ghatest5 was published.

This does seem to have marked that version as `latest`, which is unfortunate. But I can manually delete that from [here](https://github.com/matrix-org/sliding-sync/pkgs/container/sliding-sync/versions) once this lands.