### PR TITLE
Fix keys() return value starting with zero-valued keys

### DIFF
--- a/internal/util.go
+++ b/internal/util.go
@@ -1,0 +1,14 @@
+package internal
+
+// Keys returns a slice containing copies of the keys of the given map, in no particular
+// order.
+func Keys[K comparable, V any](m map[K]V) []K {
+	if m == nil {
+		return nil
+	}
+	output := make([]K, 0, len(m))
+	for key := range m {
+		output = append(output, key)
+	}
+	return output
+}

--- a/internal/util_test.go
+++ b/internal/util_test.go
@@ -25,6 +25,6 @@ func assertSlice(t *testing.T, got, want []string) {
 	sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
 
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("After sorting, got %v ubt expected %v", got, want)
+		t.Errorf("After sorting, got %v but expected %v", got, want)
 	}
 }

--- a/internal/util_test.go
+++ b/internal/util_test.go
@@ -1,0 +1,30 @@
+package internal
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestKeys(t *testing.T) {
+	assertSlice(t, Keys((map[string]int)(nil)), nil)
+	assertSlice(t, Keys(map[string]int{}), []string{})
+	assertSlice(t, Keys(map[string]int{"a": 1}), []string{"a"})
+	assertSlice(t, Keys(map[string]int{"a": 1, "b": 2, "c": 3}), []string{"a", "b", "c"})
+	assertSlice(t, Keys(map[string]int{"": 1, "!": 1, "☃": 1, "\x00": 1}), []string{"", "!", "☃", "\x00"})
+}
+
+// assertSlicesSameElements errors the test if "got" and "want" have different elements.
+// Both got and want are sorted in-place as a side effect.
+func assertSlice(t *testing.T, got, want []string) {
+	if len(got) != len(want) {
+		t.Errorf("got length %d, expected length %d", len(got), len(want))
+	}
+
+	sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+	sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("After sorting, got %v ubt expected %v", got, want)
+	}
+}

--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -231,7 +231,7 @@ func (s *ConnState) onIncomingRequest(reqCtx context.Context, req *sync3.Request
 		RoomIDToTimeline:   response.RoomIDsToTimelineEventIDs(),
 		IsInitial:          isInitial,
 		RoomIDsToLists:     s.lists.ListsByVisibleRoomIDs(s.muxedReq.Lists),
-		AllSubscribedRooms: keys(s.roomSubscriptions),
+		AllSubscribedRooms: internal.Keys(s.roomSubscriptions),
 		AllLists:           s.muxedReq.ListKeys(),
 	})
 	region.End()
@@ -574,7 +574,7 @@ func (s *ConnState) getInitialRoomData(ctx context.Context, roomSub sync3.RoomSu
 		for _, ev := range latestEvents.Timeline {
 			senders[gjson.GetBytes(ev, "sender").Str] = struct{}{}
 		}
-		roomToUsersInTimeline[roomID] = keys(senders)
+		roomToUsersInTimeline[roomID] = internal.Keys(senders)
 		roomToTimeline[roomID] = latestEvents.Timeline
 		// remember what we just loaded so if we see these events down the live stream we know to ignore them.
 		// This means that requesting a direct room subscription causes the connection to jump ahead to whatever
@@ -782,17 +782,4 @@ func clampSliceRangeToListSize(ctx context.Context, r [2]int64, totalRooms int64
 	} else {
 		return [2]int64{r[0], lastIndexWithRoom}
 	}
-}
-
-// keys returns a slice containing copies of the keys of the given map, in no particular
-// order.
-func keys[K comparable, V any](m map[K]V) []K {
-	if m == nil {
-		return nil
-	}
-	output := make([]K, len(m))
-	for key := range m {
-		output = append(output, key)
-	}
-	return output
 }

--- a/sync3/handler/connstate_live.go
+++ b/sync3/handler/connstate_live.go
@@ -122,7 +122,7 @@ func (s *connStateLive) processUpdate(ctx context.Context, update caches.Update,
 		UserID:             s.userID,
 		DeviceID:           s.deviceID,
 		RoomIDsToLists:     roomIDsToLists,
-		AllSubscribedRooms: keys(s.roomSubscriptions),
+		AllSubscribedRooms: internal.Keys(s.roomSubscriptions),
 		AllLists:           s.muxedReq.ListKeys(),
 	})
 }


### PR DESCRIPTION
Also pull this into `internal` so that other packages can reuse it

Hopefully we can use
https://pkg.go.dev/golang.org/x/exp@v0.0.0-20231006140011-7918f672742d/maps#Keys one day

Pulled out of #329.