### PR TITLE
Stop waiting for data when closing v2 servers

### DIFF
--- a/tests-integration/v3_test.go
+++ b/tests-integration/v3_test.go
@@ -207,7 +207,13 @@ func (s *testV2Server) nextResponse(userID, token string) *sync2.SyncResponse {
 		cond.Broadcast()
 	}
 	select {
-	case data := <-ch:
+	case data, stillOpen := <-ch:
+		if !stillOpen {
+			if !testutils.Quiet {
+				log.Printf("testV2Server: closing, returning null to %s %s", userID, token)
+			}
+			return nil
+		}
 		if !testutils.Quiet {
 			log.Printf(
 				"testV2Server: nextResponse %s %s returning data: [invite=%d,join=%d,leave=%d]",
@@ -228,6 +234,11 @@ func (s *testV2Server) url() string {
 }
 
 func (s *testV2Server) close() {
+	s.mu.Lock()
+	for _, ch := range s.queues {
+		close(ch)
+	}
+	s.mu.Unlock()
 	s.srv.Close()
 }
 


### PR DESCRIPTION
This makes integration tests about twice as fast for me, according to

```sh
time go test -count=1 ./tests-integration/ -v
```

Before:

real 2m4.053s
user 0m4.187s
sys  0m1.495s

After:

real 1m7.415s
user 0m3.093s
sys  0m1.347s)

