### PR TITLE
Add a separate payload for redacting state

### DIFF
--- a/state/accumulator.go
+++ b/state/accumulator.go
@@ -326,10 +326,9 @@ type AccumulateResult struct {
 	// TimelineNIDs is the list of event nids seen in a sync v2 timeline. Some of these
 	// may already be known to the proxy.
 	TimelineNIDs []int64
-	// RequiresReload is set to true when we have accumulated a non-incremental state
-	// change (typically a redaction) that requires consumers to reload the room state
-	// from the latest snapshot.
-	RequiresReload bool
+	// IncludesStateRedaction is set to true when we have accumulated a redaction to a
+	// piece of room state.
+	IncludesStateRedaction bool
 }
 
 // Accumulate internal state from a user's sync response. The timeline order MUST be in the order
@@ -546,7 +545,7 @@ func (a *Accumulator) Accumulate(txn *sqlx.Tx, userID, roomID string, timeline s
 		if err != nil {
 			return AccumulateResult{}, err
 		}
-		result.RequiresReload = currentStateRedactions > 0
+		result.IncludesStateRedaction = currentStateRedactions > 0
 	}
 
 	if err = a.invitesTable.RemoveSupersededInvites(txn, roomID, postInsertEvents); err != nil {

--- a/state/accumulator_test.go
+++ b/state/accumulator_test.go
@@ -256,7 +256,7 @@ func TestAccumulatorPromptsCacheInvalidation(t *testing.T) {
 	t.Log("We expect 3 new events and no reload required.")
 	assertValue(t, "accResult.NumNew", accResult.NumNew, 3)
 	assertValue(t, "len(accResult.TimelineNIDs)", len(accResult.TimelineNIDs), 3)
-	assertValue(t, "accResult.RequiresReload", accResult.RequiresReload, false)
+	assertValue(t, "accResult.IncludesStateRedaction", accResult.IncludesStateRedaction, false)
 
 	t.Log("Redact the old state event and the message.")
 	timeline = []json.RawMessage{
@@ -274,7 +274,7 @@ func TestAccumulatorPromptsCacheInvalidation(t *testing.T) {
 	t.Log("We expect 2 new events and no reload required.")
 	assertValue(t, "accResult.NumNew", accResult.NumNew, 2)
 	assertValue(t, "len(accResult.TimelineNIDs)", len(accResult.TimelineNIDs), 2)
-	assertValue(t, "accResult.RequiresReload", accResult.RequiresReload, false)
+	assertValue(t, "accResult.IncludesStateRedaction", accResult.IncludesStateRedaction, false)
 
 	t.Log("Redact the latest state event.")
 	timeline = []json.RawMessage{
@@ -291,7 +291,7 @@ func TestAccumulatorPromptsCacheInvalidation(t *testing.T) {
 	t.Log("We expect 1 new event and a reload required.")
 	assertValue(t, "accResult.NumNew", accResult.NumNew, 1)
 	assertValue(t, "len(accResult.TimelineNIDs)", len(accResult.TimelineNIDs), 1)
-	assertValue(t, "accResult.RequiresReload", accResult.RequiresReload, true)
+	assertValue(t, "accResult.IncludesStateRedaction", accResult.IncludesStateRedaction, true)
 }
 
 func TestAccumulatorMembershipLogs(t *testing.T) {

--- a/sync2/handler2/handler.go
+++ b/sync2/handler2/handler.go
@@ -302,9 +302,9 @@ func (h *Handler) Accumulate(ctx context.Context, userID, deviceID, roomID strin
 		return err
 	}
 
-	// Consumers should reload state before processing new timeline events.
-	if accResult.RequiresReload {
-		h.v2Pub.Notify(pubsub.ChanV2, &pubsub.V2InvalidateRoom{
+	// Consumers should reload state content before processing new timeline events.
+	if accResult.IncludesStateRedaction {
+		h.v2Pub.Notify(pubsub.ChanV2, &pubsub.V2StateRedaction{
 			RoomID: roomID,
 		})
 	}

--- a/sync3/handler/handler.go
+++ b/sync3/handler/handler.go
@@ -803,6 +803,14 @@ func (h *SyncLiveHandler) OnExpiredToken(p *pubsub.V2ExpiredToken) {
 	h.ConnMap.CloseConnsForDevice(p.UserID, p.DeviceID)
 }
 
+func (h *SyncLiveHandler) OnStateRedaction(p *pubsub.V2StateRedaction) {
+	// We only need to reload the global metadata here: mercifully, there isn't anything
+	// in the user cache that needs to be reloaded after state gets redacted.
+	ctx, task := internal.StartTask(context.Background(), "OnStateRedaction")
+	defer task.End()
+	h.GlobalCache.OnInvalidateRoom(ctx, p.RoomID)
+}
+
 func (h *SyncLiveHandler) OnInvalidateRoom(p *pubsub.V2InvalidateRoom) {
 	ctx, task := internal.StartTask(context.Background(), "OnInvalidateRoom")
 	defer task.End()


### PR DESCRIPTION
Part of #294.

I want to use `V2InvalidateRoom` to mean "gappy poll received, reload everything about the room and nuke all involved users' connections", so we can finally land #329 (or equivalent).

We already use this payload to mean "a piece of room state got redacted". In this situation we only need to reload the global cache; we don't need to nuke connections. Room state redactions happen rarely (we think) so we could get away with reusing V2InvalidateRoom for this case too. But 
- it would be nice to avoid giving M_UNKNOWN_POS to clients where we can. 
- ne'er-do-wells could abuse this by redacting their own state events in order to nuke connections. (AFAICS the default power levels do not impose a PL requirement for `m.room.redaction`.)
