### PR TITLE
Handle gappy state with a single snapshot, attempt 3

### DIFF
--- a/state/accumulator.go
+++ b/state/accumulator.go
@@ -141,69 +141,62 @@ type InitialiseResult struct {
 	// AddedEvents is true iff this call to Initialise added new state events to the DB.
 	AddedEvents bool
 	// SnapshotID is the ID of the snapshot which incorporates all added events.
-	// It has no meaning if AddedEvents is False.
+	// It has no meaning if AddedEvents is false.
 	SnapshotID int64
-	// PrependTimelineEvents is empty if the room was not initialised prior to this call.
-	// Otherwise, it is an order-preserving subset of the `state` argument to Initialise
-	// containing all events that were not persisted prior to the Initialise call. These
-	// should be prepended to the room timeline by the caller.
-	PrependTimelineEvents []json.RawMessage
+	// ReplacedExistingSnapshot is true when we created a new snapshot for the room and
+	// there a pre-existing room snapshot. It has no meaning if AddedEvents is false.
+	ReplacedExistingSnapshot bool
 }
 
-// Initialise starts a new sync accumulator for the given room using the given state as a baseline.
+// Initialise processes the state block of a V2 sync response for a particular room. If
+// the state of the room has changed, we persist any new state events and create a new
+// "snapshot" of its entire state.
 //
-// This will only take effect if this is the first time the v3 server has seen this room, and it wasn't
-// possible to get all events up to the create event (e.g Matrix HQ).
-// This function:
-// - Stores these events
-// - Sets up the current snapshot based on the state list given.
+// Summary of the logic:
 //
-// If the v3 server has seen this room before, this function
-//   - queries the DB to determine which state events are known to th server,
-//   - returns (via InitialiseResult.PrependTimelineEvents) a slice of unknown state events,
+//  0. Ensure the state block is not empty.
 //
-// and otherwise does nothing.
+//  1. Capture the current snapshot ID, possibly zero. If it is zero, ensure that the
+//     state block contains a `create event`.
+//
+//  2. Insert the events. If there are no newly inserted events, bail. If there are new
+//     events, then the state block has definitely changed. Note: we ignore cases where
+//     the state has only changed to a known subset of state events (i.e in the case of
+//     state resets, slow pollers) as it is impossible to then reconcile that state with
+//     any new events, as any "catchup" state will be ignored due to the events already
+//     existing.
+//
+//  3. Fetch the current state of the room, as a map from (type, state_key) to event.
+//     If there is no existing state snapshot, this map is the empty map.
+//     If the state hasn't altered, bail.
+//
+//  4. Create new snapshot. Update the map from (3) with the events in `state`.
+//     (There is similar logic for this in Accumulate.)
+//     Store the snapshot. Mark the room's current state as being this snapshot.
+//
+//  5. Any other processing of the new state events.
+//
+//  6. Return an "AddedEvents" bool (if true, emit an Initialise payload) and a
+//     "ReplacedSnapshot" bool (if true, emit a cache invalidation payload).
+
 func (a *Accumulator) Initialise(roomID string, state []json.RawMessage) (InitialiseResult, error) {
 	var res InitialiseResult
+	var startingSnapshotID int64
+
+	// 0. Ensure the state block is not empty.
 	if len(state) == 0 {
 		return res, nil
 	}
-	err := sqlutil.WithTransaction(a.db, func(txn *sqlx.Tx) error {
+	err := sqlutil.WithTransaction(a.db, func(txn *sqlx.Tx) (err error) {
+		// 1. Capture the current snapshot ID, checking for a create event if this is our first snapshot.
+
 		// Attempt to short-circuit. This has to be done inside a transaction to make sure
 		// we don't race with multiple calls to Initialise with the same room ID.
-		snapshotID, err := a.roomsTable.CurrentAfterSnapshotID(txn, roomID)
+		startingSnapshotID, err = a.roomsTable.CurrentAfterSnapshotID(txn, roomID)
 		if err != nil {
-			return fmt.Errorf("error fetching snapshot id for room %s: %s", roomID, err)
+			return fmt.Errorf("error fetching snapshot id for room %s: %w", roomID, err)
 		}
-		if snapshotID > 0 {
-			// Poller A has received a gappy sync v2 response with a state block, and
-			// we have seen this room before. If we knew for certain that there is some
-			// other active poller B in this room then we could safely skip this logic.
-
-			// Log at debug for now. If we find an unknown event, we'll return it so
-			// that the poller can log a warning.
-			logger.Debug().Str("room_id", roomID).Int64("snapshot_id", snapshotID).Msg("Accumulator.Initialise called with incremental state but current snapshot already exists.")
-			eventIDs := make([]string, len(state))
-			eventIDToRawEvent := make(map[string]json.RawMessage, len(state))
-			for i := range state {
-				eventID := gjson.ParseBytes(state[i]).Get("event_id")
-				if !eventID.Exists() || eventID.Type != gjson.String {
-					return fmt.Errorf("Event %d lacks an event ID", i)
-				}
-				eventIDToRawEvent[eventID.Str] = state[i]
-				eventIDs[i] = eventID.Str
-			}
-			unknownEventIDs, err := a.eventsTable.SelectUnknownEventIDs(txn, eventIDs)
-			if err != nil {
-				return fmt.Errorf("error determing which event IDs are unknown: %s", err)
-			}
-			for unknownEventID := range unknownEventIDs {
-				res.PrependTimelineEvents = append(res.PrependTimelineEvents, eventIDToRawEvent[unknownEventID])
-			}
-			return nil
-		}
-
-		// We don't have a snapshot for this room. Parse the events first.
+		// Start by parsing the events in the state block.
 		events := make([]Event, len(state))
 		for i := range events {
 			events[i] = Event{
@@ -214,77 +207,76 @@ func (a *Accumulator) Initialise(roomID string, state []json.RawMessage) (Initia
 		}
 		events = filterAndEnsureFieldsSet(events)
 		if len(events) == 0 {
-			return fmt.Errorf("failed to insert events, all events were filtered out: %w", err)
+			return fmt.Errorf("failed to parse state block, all events were filtered out: %w", err)
 		}
 
-		// Before proceeding further, ensure that we have "proper" state and not just a
-		// single stray event by looking for the create event.
-		hasCreate := false
-		for _, e := range events {
-			if e.Type == "m.room.create" && e.StateKey == "" {
-				hasCreate = true
-				break
+		if startingSnapshotID == 0 {
+			// Ensure that we have "proper" state and not "stray" events from Synapse.
+			if err = ensureStateHasCreateEvent(events); err != nil {
+				return err
 			}
 		}
-		if !hasCreate {
-			const errMsg = "cannot create first snapshot without a create event"
-			sentry.WithScope(func(scope *sentry.Scope) {
-				scope.SetContext(internal.SentryCtxKey, map[string]interface{}{
-					"room_id":   roomID,
-					"len_state": len(events),
-				})
-				sentry.CaptureMessage(errMsg)
-			})
-			logger.Warn().
-				Str("room_id", roomID).
-				Int("len_state", len(events)).
-				Msg(errMsg)
-			// the HS gave us bad data so there's no point retrying => return DataError
-			return internal.NewDataError(errMsg)
-		}
 
-		// Insert the events.
-		eventIDToNID, err := a.eventsTable.Insert(txn, events, false)
+		// 2. Insert the events and determine which ones are new.
+		newEventIDToNID, err := a.eventsTable.Insert(txn, events, false)
 		if err != nil {
 			return fmt.Errorf("failed to insert events: %w", err)
 		}
-		if len(eventIDToNID) == 0 {
-			// we don't have a current snapshot for this room but yet no events are new,
-			// no idea how this should be handled.
-			const errMsg = "Accumulator.Initialise: room has no current snapshot but also no new inserted events, doing nothing. This is probably a bug."
-			logger.Error().Str("room_id", roomID).Msg(errMsg)
-			sentry.CaptureException(fmt.Errorf(errMsg))
+		if len(newEventIDToNID) == 0 {
+			if startingSnapshotID == 0 {
+				// we don't have a current snapshot for this room but yet no events are new,
+				// no idea how this should be handled.
+				const errMsg = "Accumulator.Initialise: room has no current snapshot but also no new inserted events, doing nothing. This is probably a bug."
+				logger.Error().Str("room_id", roomID).Msg(errMsg)
+				sentry.CaptureException(fmt.Errorf(errMsg))
+			}
+			// Note: we otherwise ignore cases where the state has only changed to a
+			// known subset of state events (i.e in the case of state resets, slow
+			// pollers) as it is impossible to then reconcile that state with
+			// any new events, as any "catchup" state will be ignored due to the events
+			// already existing.
 			return nil
 		}
-
-		// pull out the event NIDs we just inserted
-		membershipEventIDs := make(map[string]struct{}, len(events))
+		newEvents := make([]Event, 0, len(newEventIDToNID))
 		for _, event := range events {
-			if event.Type == "m.room.member" {
-				membershipEventIDs[event.ID] = struct{}{}
-			}
-		}
-		memberNIDs := make([]int64, 0, len(eventIDToNID))
-		otherNIDs := make([]int64, 0, len(eventIDToNID))
-		for evID, nid := range eventIDToNID {
-			if _, exists := membershipEventIDs[evID]; exists {
-				memberNIDs = append(memberNIDs, int64(nid))
-			} else {
-				otherNIDs = append(otherNIDs, int64(nid))
+			newNid, isNew := newEventIDToNID[event.ID]
+			if isNew {
+				event.NID = newNid
+				newEvents = append(newEvents, event)
 			}
 		}
 
-		// Make a current snapshot
+		// 3. Fetch the current state of the room.
+		var currentState stateMap
+		if startingSnapshotID > 0 {
+			currentState, err = a.stateMapAtSnapshot(txn, startingSnapshotID)
+			if err != nil {
+				return fmt.Errorf("failed to load state map: %w", err)
+			}
+		} else {
+			currentState = stateMap{
+				Memberships: make(map[string]int64, len(events)),
+				Other:       make(map[[2]string]int64, len(events)),
+			}
+		}
+
+		// 4. Update the map from (3) with the new events to create a new snapshot.
+		for _, ev := range newEvents {
+			currentState.Ingest(ev)
+		}
+		memberNIDs, otherNIDs := currentState.NIDs()
 		snapshot := &SnapshotRow{
 			RoomID:           roomID,
-			MembershipEvents: pq.Int64Array(memberNIDs),
-			OtherEvents:      pq.Int64Array(otherNIDs),
+			MembershipEvents: memberNIDs,
+			OtherEvents:      otherNIDs,
 		}
 		err = a.snapshotTable.Insert(txn, snapshot)
 		if err != nil {
 			return fmt.Errorf("failed to insert snapshot: %w", err)
 		}
 		res.AddedEvents = true
+
+		// 5. Any other processing of new state events.
 		latestNID := int64(0)
 		for _, nid := range otherNIDs {
 			if nid > latestNID {
@@ -313,8 +305,16 @@ func (a *Accumulator) Initialise(roomID string, state []json.RawMessage) (Initia
 		// will have an associated state snapshot ID on the event.
 
 		// Set the snapshot ID as the current state
+		err = a.roomsTable.Upsert(txn, info, snapshot.SnapshotID, latestNID)
+		if err != nil {
+			return err
+		}
+
+		// 6. Tell the caller what happened, so they know what payloads to emit.
 		res.SnapshotID = snapshot.SnapshotID
-		return a.roomsTable.Upsert(txn, info, snapshot.SnapshotID, latestNID)
+		res.AddedEvents = true
+		res.ReplacedExistingSnapshot = startingSnapshotID > 0
+		return nil
 	})
 	return res, err
 }
@@ -651,4 +651,83 @@ func (a *Accumulator) filterToNewTimelineEvents(txn *sqlx.Tx, dedupedEvents []Ev
 	// B is seen event s[A,B,C] => s[1+1:] => [C]
 	// A is seen event s[A,B,C] => s[0+1:] => [B,C]
 	return dedupedEvents[seenIndex+1:], nil
+}
+
+func ensureStateHasCreateEvent(events []Event) error {
+	hasCreate := false
+	for _, e := range events {
+		if e.Type == "m.room.create" && e.StateKey == "" {
+			hasCreate = true
+			break
+		}
+	}
+	if !hasCreate {
+		const errMsg = "cannot create first snapshot without a create event"
+		sentry.WithScope(func(scope *sentry.Scope) {
+			scope.SetContext(internal.SentryCtxKey, map[string]interface{}{
+				"room_id":   events[0].RoomID,
+				"len_state": len(events),
+			})
+			sentry.CaptureMessage(errMsg)
+		})
+		logger.Warn().
+			Str("room_id", events[0].RoomID).
+			Int("len_state", len(events)).
+			Msg(errMsg)
+		// the HS gave us bad data so there's no point retrying => return DataError
+		return internal.NewDataError(errMsg)
+	}
+	return nil
+}
+
+type stateMap struct {
+	// state_key (user id) -> NID
+	Memberships map[string]int64
+	// type, state_key -> NID
+	Other map[[2]string]int64
+}
+
+func (s *stateMap) Ingest(e Event) (replacedNID int64) {
+	if e.Type == "m.room.member" {
+		replacedNID = s.Memberships[e.StateKey]
+		s.Memberships[e.StateKey] = e.NID
+	} else {
+		key := [2]string{e.Type, e.StateKey}
+		replacedNID = s.Other[key]
+		s.Other[key] = e.NID
+	}
+	return
+}
+
+func (s *stateMap) NIDs() (membershipNIDs, otherNIDs []int64) {
+	membershipNIDs = make([]int64, 0, len(s.Memberships))
+	otherNIDs = make([]int64, 0, len(s.Other))
+	for _, nid := range s.Memberships {
+		membershipNIDs = append(membershipNIDs, nid)
+	}
+	for _, nid := range s.Other {
+		otherNIDs = append(otherNIDs, nid)
+	}
+	return
+}
+
+func (a *Accumulator) stateMapAtSnapshot(txn *sqlx.Tx, snapID int64) (stateMap, error) {
+	snapshot, err := a.snapshotTable.Select(txn, snapID)
+	if err != nil {
+		return stateMap{}, err
+	}
+	// pull stripped events as this may be huge (think Matrix HQ)
+	events, err := a.eventsTable.SelectStrippedEventsByNIDs(txn, true, append(snapshot.MembershipEvents, snapshot.OtherEvents...))
+	if err != nil {
+		return stateMap{}, err
+	}
+
+	state := stateMap{
+		Memberships: make(map[string]int64, len(snapshot.MembershipEvents)),
+		Other:       make(map[[2]string]int64, len(snapshot.OtherEvents)),
+	}
+	for _, e := range events {
+		state.Ingest(e)
+	}
+	return state, nil
 }

--- a/state/accumulator.go
+++ b/state/accumulator.go
@@ -255,8 +255,9 @@ func (a *Accumulator) Initialise(roomID string, state []json.RawMessage) (Initia
 			}
 		} else {
 			currentState = stateMap{
+				// Typically expect Other to be small, but Memberships may be large (think: Matrix HQ.)
 				Memberships: make(map[string]int64, len(events)),
-				Other:       make(map[[2]string]int64, len(events)),
+				Other:       make(map[[2]string]int64),
 			}
 		}
 

--- a/state/accumulator_test.go
+++ b/state/accumulator_test.go
@@ -35,9 +35,8 @@ func TestAccumulatorInitialise(t *testing.T) {
 	if err != nil {
 		t.Fatalf("falied to Initialise accumulator: %s", err)
 	}
-	if !res.AddedEvents {
-		t.Fatalf("didn't add events, wanted it to")
-	}
+	assertValue(t, "res.AddedEvents", res.AddedEvents, true)
+	assertValue(t, "res.ReplacedExistingSnapshot", res.ReplacedExistingSnapshot, false)
 
 	txn, err := accumulator.db.Beginx()
 	if err != nil {
@@ -46,21 +45,21 @@ func TestAccumulatorInitialise(t *testing.T) {
 	defer txn.Rollback()
 
 	// There should be one snapshot on the current state
-	snapID, err := accumulator.roomsTable.CurrentAfterSnapshotID(txn, roomID)
+	snapID1, err := accumulator.roomsTable.CurrentAfterSnapshotID(txn, roomID)
 	if err != nil {
 		t.Fatalf("failed to select current snapshot: %s", err)
 	}
-	if snapID == 0 {
+	if snapID1 == 0 {
 		t.Fatalf("Initialise did not store a current snapshot")
 	}
-	if snapID != res.SnapshotID {
-		t.Fatalf("Initialise returned wrong snapshot ID, got %v want %v", res.SnapshotID, snapID)
+	if snapID1 != res.SnapshotID {
+		t.Fatalf("Initialise returned wrong snapshot ID, got %v want %v", res.SnapshotID, snapID1)
 	}
 
 	// this snapshot should have 1 member event and 2 other events in it
-	row, err := accumulator.snapshotTable.Select(txn, snapID)
+	row, err := accumulator.snapshotTable.Select(txn, snapID1)
 	if err != nil {
-		t.Fatalf("failed to select snapshot %d: %s", snapID, err)
+		t.Fatalf("failed to select snapshot %d: %s", snapID1, err)
 	}
 	if len(row.MembershipEvents) != 1 {
 		t.Fatalf("got %d membership events, want %d in current state snapshot", len(row.MembershipEvents), 1)
@@ -87,7 +86,7 @@ func TestAccumulatorInitialise(t *testing.T) {
 		}
 	}
 
-	// Subsequent calls do nothing and are not an error
+	// Subsequent calls with the same set of the events do nothing and are not an error.
 	res, err = accumulator.Initialise(roomID, roomEvents)
 	if err != nil {
 		t.Fatalf("falied to Initialise accumulator: %s", err)
@@ -95,6 +94,37 @@ func TestAccumulatorInitialise(t *testing.T) {
 	if res.AddedEvents {
 		t.Fatalf("added events when it shouldn't have")
 	}
+
+	// Subsequent calls with a subset of events do nothing and are not an error
+	res, err = accumulator.Initialise(roomID, roomEvents[:2])
+	if err != nil {
+		t.Fatalf("falied to Initialise accumulator: %s", err)
+	}
+	if res.AddedEvents {
+		t.Fatalf("added events when it shouldn't have")
+	}
+
+	// Subsequent calls with at least one new event expand or replace existing state.
+	// C, D, E
+	roomEvents2 := append(roomEvents[2:3],
+		[]byte(`{"event_id":"D", "type":"m.room.topic", "state_key":"", "content":{"topic":"Dr Rick Dagless MD"}}`),
+		[]byte(`{"event_id":"E", "type":"m.room.member", "state_key":"@me:localhost", "content":{"membership":"join", "displayname": "Garth""}}`),
+	)
+	res, err = accumulator.Initialise(roomID, roomEvents2)
+	assertNoError(t, err)
+	assertValue(t, "res.AddedEvents", res.AddedEvents, true)
+	assertValue(t, "res.ReplacedExistingSnapshot", res.ReplacedExistingSnapshot, true)
+
+	snapID2, err := accumulator.roomsTable.CurrentAfterSnapshotID(txn, roomID)
+	assertNoError(t, err)
+	if snapID2 == snapID1 || snapID2 == 0 {
+		t.Errorf("Expected snapID2 (%d) to be neither snapID1 (%d) nor 0", snapID2, snapID1)
+	}
+
+	row, err = accumulator.snapshotTable.Select(txn, snapID2)
+	assertNoError(t, err)
+	assertValue(t, "len(row.MembershipEvents)", len(row.MembershipEvents), 1)
+	assertValue(t, "len(row.OtherEvents)", len(row.OtherEvents), 3)
 }
 
 // Test that an unknown room shouldn't initialise if given state without a create event.
@@ -115,9 +145,9 @@ func TestAccumulatorInitialiseBadInputs(t *testing.T) {
 func TestAccumulatorAccumulate(t *testing.T) {
 	roomID := "!TestAccumulatorAccumulate:localhost"
 	roomEvents := []json.RawMessage{
-		[]byte(`{"event_id":"D", "type":"m.room.create", "state_key":"", "content":{"creator":"@me:localhost"}}`),
-		[]byte(`{"event_id":"E", "type":"m.room.member", "state_key":"@me:localhost", "content":{"membership":"join"}}`),
-		[]byte(`{"event_id":"F", "type":"m.room.join_rules", "state_key":"", "content":{"join_rule":"public"}}`),
+		[]byte(`{"event_id":"G", "type":"m.room.create", "state_key":"", "content":{"creator":"@me:localhost"}}`),
+		[]byte(`{"event_id":"H", "type":"m.room.member", "state_key":"@me:localhost", "content":{"membership":"join"}}`),
+		[]byte(`{"event_id":"I", "type":"m.room.join_rules", "state_key":"", "content":{"join_rule":"public"}}`),
 	}
 	db, close := connectToDB(t)
 	defer close()
@@ -130,11 +160,11 @@ func TestAccumulatorAccumulate(t *testing.T) {
 	// accumulate new state makes a new snapshot and removes the old snapshot
 	newEvents := []json.RawMessage{
 		// non-state event does nothing
-		[]byte(`{"event_id":"G", "type":"m.room.message","content":{"body":"Hello World","msgtype":"m.text"}}`),
+		[]byte(`{"event_id":"J", "type":"m.room.message","content":{"body":"Hello World","msgtype":"m.text"}}`),
 		// join_rules should clobber the one from initialise
-		[]byte(`{"event_id":"H", "type":"m.room.join_rules", "state_key":"", "content":{"join_rule":"public"}}`),
+		[]byte(`{"event_id":"K", "type":"m.room.join_rules", "state_key":"", "content":{"join_rule":"public"}}`),
 		// new state event should be added to the snapshot
-		[]byte(`{"event_id":"I", "type":"m.room.history_visibility", "state_key":"", "content":{"visibility":"public"}}`),
+		[]byte(`{"event_id":"L", "type":"m.room.history_visibility", "state_key":"", "content":{"visibility":"public"}}`),
 	}
 	var result AccumulateResult
 	err = sqlutil.WithTransaction(accumulator.db, func(txn *sqlx.Tx) error {

--- a/state/storage.go
+++ b/state/storage.go
@@ -365,6 +365,8 @@ func (s *Storage) ResetMetadataState(metadata *internal.RoomMetadata) error {
 
 	// For now, don't bother reloading Encrypted, PredecessorID and UpgradedRoomID.
 	// These shouldn't be changing during a room's lifetime in normal operation.
+
+	// We haven't updated LatestEventsByType because that's not part of the timeline.
 	return nil
 }
 

--- a/sync2/handler2/handler.go
+++ b/sync2/handler2/handler.go
@@ -370,20 +370,24 @@ func (h *Handler) Accumulate(ctx context.Context, userID, deviceID, roomID strin
 	return nil
 }
 
-func (h *Handler) Initialise(ctx context.Context, roomID string, state []json.RawMessage) ([]json.RawMessage, error) {
+func (h *Handler) Initialise(ctx context.Context, roomID string, state []json.RawMessage) error {
 	res, err := h.Store.Initialise(roomID, state)
 	if err != nil {
 		logger.Err(err).Int("state", len(state)).Str("room", roomID).Msg("V2: failed to initialise room")
 		internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(err)
-		return nil, err
+		return err
 	}
-	if res.AddedEvents {
+	if res.ReplacedExistingSnapshot {
+		h.v2Pub.Notify(pubsub.ChanV2, &pubsub.V2InvalidateRoom{
+			RoomID: roomID,
+		})
+	} else if res.AddedEvents {
 		h.v2Pub.Notify(pubsub.ChanV2, &pubsub.V2Initialise{
 			RoomID:      roomID,
 			SnapshotNID: res.SnapshotID,
 		})
 	}
-	return res.PrependTimelineEvents, nil
+	return nil
 }
 
 func (h *Handler) SetTyping(ctx context.Context, pollerID sync2.PollerID, roomID string, ephEvent json.RawMessage) {

--- a/sync2/poller.go
+++ b/sync2/poller.go
@@ -40,7 +40,7 @@ type V2DataReceiver interface {
 	// Initialise the room, if it hasn't been already. This means the state section of the v2 response.
 	// If given a state delta from an incremental sync, returns the slice of all state events unknown to the DB.
 	// Return an error to stop the since token advancing.
-	Initialise(ctx context.Context, roomID string, state []json.RawMessage) ([]json.RawMessage, error) // snapshot ID?
+	Initialise(ctx context.Context, roomID string, state []json.RawMessage) error // snapshot ID?
 	// SetTyping indicates which users are typing.
 	SetTyping(ctx context.Context, pollerID PollerID, roomID string, ephEvent json.RawMessage)
 	// Sent when there is a new receipt
@@ -326,11 +326,11 @@ func (h *PollerMap) Accumulate(ctx context.Context, userID, deviceID, roomID str
 	wg.Wait()
 	return
 }
-func (h *PollerMap) Initialise(ctx context.Context, roomID string, state []json.RawMessage) (result []json.RawMessage, err error) {
+func (h *PollerMap) Initialise(ctx context.Context, roomID string, state []json.RawMessage) (err error) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	h.executor <- func() {
-		result, err = h.callbacks.Initialise(ctx, roomID, state)
+		err = h.callbacks.Initialise(ctx, roomID, state)
 		wg.Done()
 	}
 	wg.Wait()
@@ -789,29 +789,13 @@ func (p *poller) parseRoomsResponse(ctx context.Context, res *SyncResponse) erro
 	for roomID, roomData := range res.Rooms.Join {
 		if len(roomData.State.Events) > 0 {
 			stateCalls++
-			prependStateEvents, err := p.receiver.Initialise(ctx, roomID, roomData.State.Events)
+			if roomData.Timeline.Limited {
+				p.trackGappyStateSize(len(roomData.State.Events))
+			}
+			err := p.receiver.Initialise(ctx, roomID, roomData.State.Events)
 			if err != nil {
 				lastErrs = append(lastErrs, fmt.Errorf("Initialise[%s]: %w", roomID, err))
 				continue
-			}
-			if len(prependStateEvents) > 0 {
-				// The poller has just learned of these state events due to an
-				// incremental poller sync; we must have missed the opportunity to see
-				// these down /sync in a timeline. As a workaround, inject these into
-				// the timeline now so that future events are received under the
-				// correct room state.
-				const warnMsg = "parseRoomsResponse: prepending state events to timeline after gappy poll"
-				logger.Warn().Str("room_id", roomID).Int("prependStateEvents", len(prependStateEvents)).Msg(warnMsg)
-				hub := internal.GetSentryHubFromContextOrDefault(ctx)
-				hub.WithScope(func(scope *sentry.Scope) {
-					scope.SetContext(internal.SentryCtxKey, map[string]interface{}{
-						"room_id":                  roomID,
-						"num_prepend_state_events": len(prependStateEvents),
-					})
-					hub.CaptureMessage(warnMsg)
-				})
-				p.trackGappyStateSize(len(prependStateEvents))
-				roomData.Timeline.Events = append(prependStateEvents, roomData.Timeline.Events...)
 			}
 		}
 		// process typing/receipts before events so we seed the caches correctly for when we return the room

--- a/sync2/poller_test.go
+++ b/sync2/poller_test.go
@@ -830,8 +830,8 @@ func TestPollerResendsOnCallbackError(t *testing.T) {
 			// generate a receiver which errors for the right callback
 			generateReceiver: func() V2DataReceiver {
 				return &overrideDataReceiver{
-					initialise: func(ctx context.Context, roomID string, state []json.RawMessage) ([]json.RawMessage, error) {
-						return nil, fmt.Errorf("initialise error")
+					initialise: func(ctx context.Context, roomID string, state []json.RawMessage) error {
+						return fmt.Errorf("initialise error")
 					},
 				}
 			},
@@ -1273,7 +1273,7 @@ func (a *mockDataReceiver) Accumulate(ctx context.Context, userID, deviceID, roo
 	a.timelines[roomID] = append(a.timelines[roomID], timeline.Events...)
 	return nil
 }
-func (a *mockDataReceiver) Initialise(ctx context.Context, roomID string, state []json.RawMessage) ([]json.RawMessage, error) {
+func (a *mockDataReceiver) Initialise(ctx context.Context, roomID string, state []json.RawMessage) error {
 	a.states[roomID] = state
 	if a.incomingProcess != nil {
 		a.incomingProcess <- struct{}{}
@@ -1283,7 +1283,7 @@ func (a *mockDataReceiver) Initialise(ctx context.Context, roomID string, state 
 	}
 	// The return value is a list of unknown state events to be prepended to the room
 	// timeline. Untested here---return nil for now.
-	return nil, nil
+	return nil
 }
 func (s *mockDataReceiver) UpdateDeviceSince(ctx context.Context, userID, deviceID, since string) {
 	s.mu.Lock()
@@ -1296,7 +1296,7 @@ func (s *mockDataReceiver) UpdateDeviceSince(ctx context.Context, userID, device
 
 type overrideDataReceiver struct {
 	accumulate          func(ctx context.Context, userID, deviceID, roomID, prevBatch string, timeline []json.RawMessage) error
-	initialise          func(ctx context.Context, roomID string, state []json.RawMessage) ([]json.RawMessage, error)
+	initialise          func(ctx context.Context, roomID string, state []json.RawMessage) error
 	setTyping           func(ctx context.Context, pollerID PollerID, roomID string, ephEvent json.RawMessage)
 	updateDeviceSince   func(ctx context.Context, userID, deviceID, since string)
 	addToDeviceMessages func(ctx context.Context, userID, deviceID string, msgs []json.RawMessage) error
@@ -1316,9 +1316,9 @@ func (s *overrideDataReceiver) Accumulate(ctx context.Context, userID, deviceID,
 	}
 	return s.accumulate(ctx, userID, deviceID, roomID, timeline.PrevBatch, timeline.Events)
 }
-func (s *overrideDataReceiver) Initialise(ctx context.Context, roomID string, state []json.RawMessage) ([]json.RawMessage, error) {
+func (s *overrideDataReceiver) Initialise(ctx context.Context, roomID string, state []json.RawMessage) error {
 	if s.initialise == nil {
-		return nil, nil
+		return nil
 	}
 	return s.initialise(ctx, roomID, state)
 }

--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -771,10 +771,3 @@ func (u *UserCache) ShouldIgnore(userID string) bool {
 	_, ignored := u.ignoredUsers[userID]
 	return ignored
 }
-
-func (u *UserCache) OnInvalidateRoom(ctx context.Context, roomID string) {
-	// Nothing for now. In UserRoomData the fields dependant on room state are
-	// IsDM, IsInvite, HasLeft, Invite, CanonicalisedName, ResolvedAvatarURL, Spaces.
-	// Not clear to me if we need to reload these or if we will inherit any changes from
-	// the global cache.
-}

--- a/sync3/connmap.go
+++ b/sync3/connmap.go
@@ -181,6 +181,19 @@ func (m *ConnMap) connIDsForDevice(userID, deviceID string) []ConnID {
 	return connIDs
 }
 
+// CloseConnsForUser closes all conns for a given user. Returns the number of conns closed.
+func (m *ConnMap) CloseConnsForUser(userID string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	conns := m.userIDToConn[userID]
+	logger.Trace().Str("user", userID).Int("num_conns", len(conns)).Msg("closing all device connections due to CloseConn()")
+
+	for _, cid := range conns {
+		m.cache.Remove(cid.String()) // this will fire TTL callbacks which calls closeConn
+	}
+	return len(conns)
+}
+
 func (m *ConnMap) closeConnExpires(connID string, value interface{}) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/sync3/dispatcher.go
+++ b/sync3/dispatcher.go
@@ -275,22 +275,7 @@ func (d *Dispatcher) notifyListeners(ctx context.Context, ed *caches.EventData, 
 	}
 }
 
-func (d *Dispatcher) OnInvalidateRoom(ctx context.Context, roomID string) {
-	// First dispatch to the global cache.
-	receiver, ok := d.userToReceiver[DispatcherAllUsers]
-	if !ok {
-		logger.Error().Msgf("No receiver for global cache")
-	}
-	receiver.OnInvalidateRoom(ctx, roomID)
-
-	// Then dispatch to any users who are joined to that room.
-	joinedUsers, _ := d.jrt.JoinedUsersForRoom(roomID, nil)
-	d.userToReceiverMu.RLock()
-	defer d.userToReceiverMu.RUnlock()
-	for _, userID := range joinedUsers {
-		receiver = d.userToReceiver[userID]
-		if receiver != nil {
-			receiver.OnInvalidateRoom(ctx, roomID)
-		}
-	}
+func (d *Dispatcher) OnInvalidateRoom(roomID string, joins, invites []string) {
+	// Reset the joined room tracker.
+	d.jrt.ReloadMembershipsForRoom(roomID, joins, invites)
 }

--- a/sync3/dispatcher.go
+++ b/sync3/dispatcher.go
@@ -55,6 +55,12 @@ func (d *Dispatcher) Startup(roomToJoinedUsers map[string][]string) error {
 	return nil
 }
 
+func (d *Dispatcher) Unregister(userID string) {
+	d.userToReceiverMu.Lock()
+	defer d.userToReceiverMu.Unlock()
+	delete(d.userToReceiver, userID)
+}
+
 // UnregisterBulk accepts a slice of user IDs to unregister. The given users need not
 // already be registered (in which case unregistering them is a no-op). Returns the
 // list of users that were unregistered.
@@ -62,7 +68,7 @@ func (d *Dispatcher) UnregisterBulk(userIDs []string) []string {
 	d.userToReceiverMu.Lock()
 	defer d.userToReceiverMu.Unlock()
 
-	unregistered := make([]string)
+	unregistered := make([]string, 0)
 	for _, userID := range userIDs {
 		_, exists := d.userToReceiver[userID]
 		if exists {

--- a/sync3/dispatcher.go
+++ b/sync3/dispatcher.go
@@ -55,10 +55,22 @@ func (d *Dispatcher) Startup(roomToJoinedUsers map[string][]string) error {
 	return nil
 }
 
-func (d *Dispatcher) Unregister(userID string) {
+// UnregisterBulk accepts a slice of user IDs to unregister. The given users need not
+// already be registered (in which case unregistering them is a no-op). Returns the
+// list of users that were unregistered.
+func (d *Dispatcher) UnregisterBulk(userIDs []string) []string {
 	d.userToReceiverMu.Lock()
 	defer d.userToReceiverMu.Unlock()
-	delete(d.userToReceiver, userID)
+
+	unregistered := make([]string)
+	for _, userID := range userIDs {
+		_, exists := d.userToReceiver[userID]
+		if exists {
+			delete(d.userToReceiver, userID)
+			unregistered = append(unregistered, userID)
+		}
+	}
+	return unregistered
 }
 
 func (d *Dispatcher) Register(ctx context.Context, userID string, r Receiver) error {

--- a/sync3/dispatcher.go
+++ b/sync3/dispatcher.go
@@ -24,7 +24,6 @@ type Receiver interface {
 	OnNewEvent(ctx context.Context, event *caches.EventData)
 	OnReceipt(ctx context.Context, receipt internal.Receipt)
 	OnEphemeralEvent(ctx context.Context, roomID string, ephEvent json.RawMessage)
-	OnInvalidateRoom(ctx context.Context, roomID string)
 	// OnRegistered is called after a successful call to Dispatcher.Register
 	OnRegistered(ctx context.Context) error
 }

--- a/sync3/handler/handler.go
+++ b/sync3/handler/handler.go
@@ -844,7 +844,6 @@ func (h *SyncLiveHandler) OnInvalidateRoom(p *pubsub.V2InvalidateRoom) {
 	involvedUsers = append(involvedUsers, invites...)
 	involvedUsers = append(involvedUsers, leaves...)
 
-	// 2. Reload the joined-room tracker.
 	if err != nil {
 		hub := internal.GetSentryHubFromContextOrDefault(ctx)
 		hub.WithScope(func(scope *sentry.Scope) {
@@ -856,8 +855,10 @@ func (h *SyncLiveHandler) OnInvalidateRoom(p *pubsub.V2InvalidateRoom) {
 		logger.Err(err).
 			Str("room_id", p.RoomID).
 			Msg("Failed to fetch members after cache invalidation")
+		return
 	}
 
+	// 2. Reload the joined-room tracker.
 	h.Dispatcher.OnInvalidateRoom(p.RoomID, joins, invites)
 
 	// 3. Destroy involved users' caches.

--- a/sync3/handler/handler.go
+++ b/sync3/handler/handler.go
@@ -862,8 +862,9 @@ func (h *SyncLiveHandler) OnInvalidateRoom(p *pubsub.V2InvalidateRoom) {
 	h.Dispatcher.OnInvalidateRoom(p.RoomID, joins, invites)
 
 	// 3. Destroy involved users' caches.
-	for _, userID := range involvedUsers {
-		h.Dispatcher.Unregister(userID)
+	// We filter to only those users which had a userCache registered to receive updates.
+	unregistered := h.Dispatcher.UnregisterBulk(involvedUsers)
+	for _, userID := range unregistered {
 		h.userCaches.Delete(userID)
 	}
 

--- a/sync3/handler/handler.go
+++ b/sync3/handler/handler.go
@@ -869,10 +869,8 @@ func (h *SyncLiveHandler) OnInvalidateRoom(p *pubsub.V2InvalidateRoom) {
 	}
 
 	// 4. Destroy involved users' connections.
-	var destroyed int
-	for _, userID := range involvedUsers {
-		destroyed += h.ConnMap.CloseConnsForUser(userID)
-	}
+	// Since creating a conn creates a user cache, it is safe to loop over
+	destroyed := h.ConnMap.CloseConnsForUsers(unregistered)
 	if h.destroyedConns != nil {
 		h.destroyedConns.Add(float64(destroyed))
 	}


### PR DESCRIPTION
A third iteration of "deal with the gappy poll problem".

I pulled out all the independent bits from #329 to other PRs. What was left fell into two categories: a) the original logic for trying to push out live updates with the gappy poll changes; and b) the logic for nuking connections. This PR consists of b) but not a).

Ancestry: #310 -> #329 -> this.
Closes #294.
Closes #232.