### PR TITLE
Modify which events get returned when requesting initial timeline events

### DIFF
--- a/state/storage.go
+++ b/state/storage.go
@@ -701,37 +701,30 @@ func (s *Storage) RoomStateAfterEventPosition(ctx context.Context, roomIDs []str
 // - with NIDs <= `to`.
 // Up to `limit` events are chosen per room.
 func (s *Storage) LatestEventsInRooms(userID string, roomIDs []string, to int64, limit int) (map[string]*LatestEvents, error) {
-	roomIDToRanges, err := s.visibleEventNIDsBetweenForRooms(userID, roomIDs, 0, to)
+	roomIDToRange, err := s.visibleEventNIDsBetweenForRooms(userID, roomIDs, 0, to)
 	if err != nil {
 		return nil, err
 	}
 	result := make(map[string]*LatestEvents, len(roomIDs))
 	err = sqlutil.WithTransaction(s.Accumulator.db, func(txn *sqlx.Tx) error {
-		for roomID, ranges := range roomIDToRanges {
+		for roomID, r := range roomIDToRange {
 			var earliestEventNID int64
 			var latestEventNID int64
 			var roomEvents []json.RawMessage
-			// start at the most recent range as we want to return the most recent `limit` events
-			for i := len(ranges) - 1; i >= 0; i-- {
+			// the most recent event will be first
+			events, err := s.EventsTable.SelectLatestEventsBetween(txn, roomID, r[0]-1, r[1], limit)
+			if err != nil {
+				return fmt.Errorf("room %s failed to SelectEventsBetween: %s", roomID, err)
+			}
+			// keep pushing to the front so we end up with A,B,C
+			for _, ev := range events {
+				if latestEventNID == 0 { // set first time and never again
+					latestEventNID = ev.NID
+				}
+				roomEvents = append([]json.RawMessage{ev.JSON}, roomEvents...)
+				earliestEventNID = ev.NID
 				if len(roomEvents) >= limit {
 					break
-				}
-				r := ranges[i]
-				// the most recent event will be first
-				events, err := s.EventsTable.SelectLatestEventsBetween(txn, roomID, r[0]-1, r[1], limit)
-				if err != nil {
-					return fmt.Errorf("room %s failed to SelectEventsBetween: %s", roomID, err)
-				}
-				// keep pushing to the front so we end up with A,B,C
-				for _, ev := range events {
-					if latestEventNID == 0 { // set first time and never again
-						latestEventNID = ev.NID
-					}
-					roomEvents = append([]json.RawMessage{ev.JSON}, roomEvents...)
-					earliestEventNID = ev.NID
-					if len(roomEvents) >= limit {
-						break
-					}
 				}
 			}
 			latestEvents := LatestEvents{
@@ -756,7 +749,7 @@ func (s *Storage) LatestEventsInRooms(userID string, roomIDs []string, to int64,
 // visibleEventNIDsBetweenForRooms determines which events a given user has permission to see.
 // It accepts a nid range [from, to]. For each given room, it calculates the NID ranges
 // [A1, B1], [A2, B2], ... within [from, to] in which the user has permission to see events.
-func (s *Storage) visibleEventNIDsBetweenForRooms(userID string, roomIDs []string, from, to int64) (map[string][][2]int64, error) {
+func (s *Storage) visibleEventNIDsBetweenForRooms(userID string, roomIDs []string, from, to int64) (map[string][2]int64, error) {
 	// load *THESE* joined rooms for this user at from (inclusive)
 	var membershipEvents []Event
 	var err error
@@ -782,7 +775,7 @@ func (s *Storage) visibleEventNIDsBetweenForRooms(userID string, roomIDs []strin
 }
 
 // Work out the NID ranges to pull events from for this user. Given a from and to event nid stream position,
-// this function returns a map of room ID to a slice of 2-element from|to positions. These positions are
+// this function returns a map of room ID to a 2-element from|to positions. These positions are
 // all INCLUSIVE, and the client should be informed of these events at some point. For example:
 //
 //	                  Stream Positions
@@ -793,20 +786,23 @@ func (s *Storage) visibleEventNIDsBetweenForRooms(userID string, roomIDs []strin
 //
 //	E=message event, M=membership event, followed by user letter, followed by 'i' or 'j' or 'l' for invite|join|leave
 //
-//	- For Room A: from=1, to=10, returns { RoomA: [ [1,10] ]}  (tests events in joined room)
-//	- For Room B: from=1, to=10, returns { RoomB: [ [5,10] ]}  (tests joining a room starts events)
-//	- For Room C: from=1, to=10, returns { RoomC: [ [0,9] ]}  (tests leaving a room stops events)
+//	- For Room A: from=1, to=10, returns { RoomA: [ 1,10 ]}  (tests events in joined room)
+//	- For Room B: from=1, to=10, returns { RoomB: [ 5,10 ]}  (tests joining a room starts events)
+//	- For Room C: from=1, to=10, returns { RoomC: [ 0,9 ]}  (tests leaving a room stops events)
 //
-// Multiple slices can occur when a user leaves and re-joins the same room, and invites are same-element positions:
+// In cases where a user joins/leaves a room multiple times in the nid range, only the last range is returned.
+// This is critical to ensure we don't skip out timeline events due to history visibility (which the proxy defers
+// to the upstream HS for). See https://github.com/matrix-org/sliding-sync/issues/365 for what happens if we returned
+// all ranges.
 //
 //	                   Stream Positions
 //	         1     2   3    4   5   6   7   8   9   10  11  12  13  14  15
 //	 Room D  Maj                E   Mal E   Maj E   Mal E
 //	 Room E        E   Mai  E                               E   Maj E   E
 //
-//	- For Room D: from=1, to=15 returns { RoomD: [ [1,6], [8,10] ] } (tests multi-join/leave)
-//	- For Room E: from=1, to=15 returns { RoomE: [ [3,3], [13,15] ] } (tests invites)
-func (s *Storage) VisibleEventNIDsBetween(userID string, from, to int64) (map[string][][2]int64, error) {
+//	- For Room D: from=1, to=15 returns { RoomD: [ 8,10 ] } (tests multi-join/leave)
+//	- For Room E: from=1, to=15 returns { RoomE: [ 13,15 ] } (tests invites)
+func (s *Storage) VisibleEventNIDsBetween(userID string, from, to int64) (map[string][2]int64, error) {
 	// load *ALL* joined rooms for this user at from (inclusive)
 	joinTimingsAtFromByRoomID, err := s.JoinedRoomsAfterPosition(userID, from)
 	if err != nil {
@@ -822,7 +818,7 @@ func (s *Storage) VisibleEventNIDsBetween(userID string, from, to int64) (map[st
 	return s.visibleEventNIDsWithData(joinTimingsAtFromByRoomID, membershipEvents, userID, from, to)
 }
 
-func (s *Storage) visibleEventNIDsWithData(joinTimingsAtFromByRoomID map[string]internal.EventMetadata, membershipEvents []Event, userID string, from, to int64) (map[string][][2]int64, error) {
+func (s *Storage) visibleEventNIDsWithData(joinTimingsAtFromByRoomID map[string]internal.EventMetadata, membershipEvents []Event, userID string, from, to int64) (map[string][2]int64, error) {
 	// load membership events in order and bucket based on room ID
 	roomIDToLogs := make(map[string][]membershipEvent)
 	for _, ev := range membershipEvents {
@@ -835,13 +831,11 @@ func (s *Storage) visibleEventNIDsWithData(joinTimingsAtFromByRoomID map[string]
 	}
 
 	// Performs the algorithm
-	calculateVisibleEventNIDs := func(isJoined bool, fromIncl, toIncl int64, logs []membershipEvent) [][2]int64 {
+	calculateVisibleEventNIDs := func(isJoined bool, fromIncl, toIncl int64, logs []membershipEvent) [2]int64 {
 		// short circuit when there are no membership deltas
 		if len(logs) == 0 {
-			return [][2]int64{
-				{
-					fromIncl, toIncl,
-				},
+			return [2]int64{
+				fromIncl, toIncl, // TODO: is this actually valid? Surely omitting it is the right answer?
 			}
 		}
 		var result [][2]int64
@@ -879,11 +873,16 @@ func (s *Storage) visibleEventNIDsWithData(joinTimingsAtFromByRoomID map[string]
 		if isJoined {
 			result = append(result, [2]int64{startIndex, toIncl})
 		}
-		return result
+		if len(result) == 0 {
+			return [2]int64{}
+		}
+		// we only care about the LAST nid range, otherwise we can end up with gaps being returned in the
+		// timeline. See https://github.com/matrix-org/sliding-sync/issues/365
+		return result[len(result)-1]
 	}
 
 	// For each joined room, perform the algorithm and delete the logs afterwards
-	result := make(map[string][][2]int64)
+	result := make(map[string][2]int64)
 	for joinedRoomID, _ := range joinTimingsAtFromByRoomID {
 		roomResult := calculateVisibleEventNIDs(true, from, to, roomIDToLogs[joinedRoomID])
 		result[joinedRoomID] = roomResult

--- a/tests-e2e/client_test.go
+++ b/tests-e2e/client_test.go
@@ -6,11 +6,13 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/matrix-org/complement/b"
 	"github.com/matrix-org/complement/client"
+	"github.com/matrix-org/complement/must"
 	"github.com/matrix-org/sliding-sync/sync3"
 	"github.com/tidwall/gjson"
 )
@@ -41,6 +43,19 @@ type CSAPI struct {
 	Localpart string
 	Domain    string
 	AvatarURL string
+}
+
+// TODO: put this in Complement at some point? Check usage.
+func (c *CSAPI) Scrollback(t *testing.T, roomID, prevBatch string, limit int) gjson.Result {
+	t.Helper()
+	res := c.MustDo(t, "GET", []string{
+		"_matrix", "client", "v3", "rooms", roomID, "messages",
+	}, client.WithQueries(url.Values{
+		"dir":   []string{"b"},
+		"from":  []string{prevBatch},
+		"limit": []string{strconv.Itoa(limit)},
+	}))
+	return must.ParseJSON(t, res.Body)
 }
 
 // SlidingSync performs a single sliding sync request. Fails on non 2xx

--- a/tests-e2e/timeline_test.go
+++ b/tests-e2e/timeline_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Regression test to make sure that given:
-// - Alice invite Bob
+// - Alice invite Bob (shared history visibility)
 // - Alice send message
 // - Bob join room
 // The proxy returns:

--- a/tests-e2e/timeline_test.go
+++ b/tests-e2e/timeline_test.go
@@ -1,0 +1,68 @@
+package syncv3_test
+
+import (
+	"testing"
+
+	"github.com/matrix-org/complement/b"
+	"github.com/matrix-org/sliding-sync/sync3"
+	"github.com/matrix-org/sliding-sync/testutils/m"
+)
+
+// Regression test to make sure that given:
+// - Alice invite Bob
+// - Alice send message
+// - Bob join room
+// The proxy returns either:
+// - all 3 events (if allowed by history visibility) OR
+// - Bob's join only, with a suitable prev_batch token
+// and never:
+// - invite then join, omitting the msg.
+func TestTimelineIsCorrectWhenTransitioningFromInviteToJoin(t *testing.T) {
+	alice := registerNewUser(t)
+	bob := registerNewUser(t)
+
+	roomID := alice.MustCreateRoom(t, map[string]interface{}{
+		"preset": "trusted_private_chat",
+		"invite": []string{bob.UserID},
+	})
+	aliceRes := alice.SlidingSyncUntilMembership(t, "", roomID, bob, "invite")
+	bobRes := bob.SlidingSync(t, sync3.Request{
+		Lists: map[string]sync3.RequestList{
+			"a": {
+				RoomSubscription: sync3.RoomSubscription{
+					TimelineLimit: 4,
+				},
+				Ranges: sync3.SliceRanges{{0, 20}},
+			},
+		},
+	})
+	m.MatchResponse(t, bobRes, m.MatchRoomSubscriptionsStrict(map[string][]m.RoomMatcher{
+		roomID: {
+			m.MatchInviteCount(1),
+			m.MatchRoomHasInviteState(),
+			MatchRoomTimeline([]Event{{
+				Type:     "m.room.member",
+				StateKey: &bob.UserID,
+				Content: map[string]interface{}{
+					"membership":  "invite",
+					"displayname": bob.Localpart,
+				},
+			}}),
+		},
+	}))
+
+	eventID := alice.Unsafe_SendEventUnsynced(t, roomID, b.Event{
+		Type: "m.room.message",
+		Content: map[string]interface{}{
+			"msgtype": "m.text",
+			"body":    "After invite, before join",
+		},
+	})
+	aliceRes = alice.SlidingSyncUntilEventID(t, aliceRes.Pos, roomID, eventID)
+
+	bob.MustJoinRoom(t, roomID, []string{"hs1"})
+	aliceRes = alice.SlidingSyncUntilMembership(t, aliceRes.Pos, roomID, bob, "join")
+
+	bobRes = bob.SlidingSync(t, sync3.Request{}, WithPos(bobRes.Pos))
+	m.MatchResponse(t, bobRes, m.LogResponse(t))
+}


### PR DESCRIPTION
As outlined in #365, we were trying to be too smart before by calculating all the ranges for the room and returning them as a slice of from/to positions. This neglected to consider when history visibility was set to world_readable/shared/invited. In those scenarios, if the invite and join were in close proximity in the timeline (which is fairly typical), such that the `timeline_limit` would encompass both the invite and the join, the calculated timeline would incorrectly omit the events between the invite and the join. This is very bad, because it means the client has no way to fetch those messages using `/messages`, as the `prev_batch` token will relate to the _invite_ (`timeline[0]`).

This PR fixes this by only returning a single range, the last joined range for that user. This ensure the prev_batch token is always correct, so the client can hit `/messages` with it and the upstream HS can calculate history visibility.

It's worth noting that there isn't much of a tradeoff here. The old behaviour was worse in almost all circumstances. It was only "better" in the rare case of:
 - the room has `joined` history visibility
 - the timeline limit encompasses multiple join/leave memberships for the connecting user.

In that one case, the proxy would be able to return more timeline events correctly, thus potentially cutting the need for a `/messages` hit.

It looks like this bug has sat in the codebase since the beginning, and whilst we do have membership transition tests, and we did know we were conservative on history visibility checks, we didn't combine the two in any tests to check that clients can get the data they need. This PR also adds a regression test which explicitly hits `/messages` with the provided `prev_batch` token to ensure that clients see the right data.