### PR TITLE
bugfix: when connections expire, only delete the affected connection

### DIFF
--- a/sync3/connmap.go
+++ b/sync3/connmap.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/ReneKroon/ttlcache/v2"
+	"github.com/matrix-org/sliding-sync/internal"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -169,6 +170,7 @@ func (m *ConnMap) CloseConnsForDevice(userID, deviceID string) {
 		err := m.cache.Remove(cid.String()) // this will fire TTL callbacks which calls closeConn
 		if err != nil {
 			logger.Err(err).Str("cid", cid.String()).Msg("CloseConnsForDevice: cid did not exist in ttlcache")
+			internal.GetSentryHubFromContextOrDefault(context.Background()).CaptureException(err)
 		}
 	}
 }
@@ -199,6 +201,7 @@ func (m *ConnMap) CloseConnsForUsers(userIDs []string) (closed int) {
 			err := m.cache.Remove(conn.String()) // this will fire TTL callbacks which calls closeConn
 			if err != nil {
 				logger.Err(err).Str("cid", conn.String()).Msg("CloseConnsForDevice: cid did not exist in ttlcache")
+				internal.GetSentryHubFromContextOrDefault(context.Background()).CaptureException(err)
 			}
 		}
 		closed += len(conns)

--- a/sync3/connmap.go
+++ b/sync3/connmap.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/ReneKroon/ttlcache/v2"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -228,10 +230,11 @@ func (m *ConnMap) closeConn(conn *Conn) {
 	h := conn.handler
 	conns := m.userIDToConn[conn.UserID]
 	for i := 0; i < len(conns); i++ {
-		if conns[i].DeviceID == conn.DeviceID {
+		if conns[i].DeviceID == conn.DeviceID && conns[i].CID == conn.CID {
 			// delete without preserving order
-			conns[i] = conns[len(conns)-1]
-			conns = conns[:len(conns)-1]
+			conns[i] = nil // allow GC
+			conns = slices.Delete(conns, i, i+1)
+			i--
 		}
 	}
 	m.userIDToConn[conn.UserID] = conns

--- a/sync3/connmap.go
+++ b/sync3/connmap.go
@@ -164,7 +164,10 @@ func (m *ConnMap) CloseConnsForDevice(userID, deviceID string) {
 	// gather open connections for this user|device
 	connIDs := m.connIDsForDevice(userID, deviceID)
 	for _, cid := range connIDs {
-		m.cache.Remove(cid.String()) // this will fire TTL callbacks which calls closeConn
+		err := m.cache.Remove(cid.String()) // this will fire TTL callbacks which calls closeConn
+		if err != nil {
+			logger.Err(err).Str("cid", cid.String()).Msg("CloseConnsForDevice: cid did not exist in ttlcache")
+		}
 	}
 }
 
@@ -191,7 +194,10 @@ func (m *ConnMap) CloseConnsForUsers(userIDs []string) (closed int) {
 		logger.Trace().Str("user", userID).Int("num_conns", len(conns)).Msg("closing all device connections due to CloseConn()")
 
 		for _, conn := range conns {
-			m.cache.Remove(conn.String()) // this will fire TTL callbacks which calls closeConn
+			err := m.cache.Remove(conn.String()) // this will fire TTL callbacks which calls closeConn
+			if err != nil {
+				logger.Err(err).Str("cid", conn.String()).Msg("CloseConnsForDevice: cid did not exist in ttlcache")
+			}
 		}
 		closed += len(conns)
 	}

--- a/sync3/connmap_test.go
+++ b/sync3/connmap_test.go
@@ -87,7 +87,7 @@ func TestConnMap_CloseConnsForUser(t *testing.T) {
 	time.Sleep(100 * time.Millisecond) // some stuff happens asyncly in goroutines
 	must.Equal(t, num, 6, "unexpected number of closed conns")
 
-	// Destroy should have been called for all alice|A connections
+	// Destroy should have been called for all alice connections
 	assertDestroyedConns(t, cidToConn, func(cid ConnID) bool {
 		return cid.UserID == alice
 	})

--- a/sync3/connmap_test.go
+++ b/sync3/connmap_test.go
@@ -1,0 +1,161 @@
+package sync3
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/matrix-org/complement/must"
+	"github.com/matrix-org/sliding-sync/sync3/caches"
+)
+
+const (
+	alice = "@alice:localhost"
+	bob   = "@bob:localhost"
+)
+
+func TestConnMap(t *testing.T) {
+	cm := NewConnMap(false, time.Minute)
+	cid := ConnID{UserID: alice, DeviceID: "A", CID: "room-list"}
+	_, cancel := context.WithCancel(context.Background())
+	conn := cm.CreateConn(cid, cancel, func() ConnHandler {
+		return &mockConnHandler{}
+	})
+	must.Equal(t, conn.ConnID, cid, "cid mismatch")
+
+	// lookups work
+	must.Equal(t, cm.Conn(cid), conn, "*Conn wasn't the same when fetched via Conn(ConnID)")
+	conns := cm.Conns(cid.UserID, cid.DeviceID)
+	must.Equal(t, len(conns), 1, "Conns length mismatch")
+	must.Equal(t, conns[0], conn, "*Conn wasn't the same when fetched via Conns()[0]")
+}
+
+func TestConnMap_CloseConnsForDevice(t *testing.T) {
+	cm := NewConnMap(false, time.Minute)
+	otherCID := ConnID{UserID: bob, DeviceID: "A", CID: "room-list"}
+	cidToConn := map[ConnID]*Conn{
+		{UserID: alice, DeviceID: "A", CID: "room-list"}:     nil,
+		{UserID: alice, DeviceID: "A", CID: "encryption"}:    nil,
+		{UserID: alice, DeviceID: "A", CID: "notifications"}: nil,
+		{UserID: alice, DeviceID: "B", CID: "room-list"}:     nil,
+		{UserID: alice, DeviceID: "B", CID: "encryption"}:    nil,
+		{UserID: alice, DeviceID: "B", CID: "notifications"}: nil,
+		otherCID: nil,
+	}
+	for cid := range cidToConn {
+		_, cancel := context.WithCancel(context.Background())
+		conn := cm.CreateConn(cid, cancel, func() ConnHandler {
+			return &mockConnHandler{}
+		})
+		cidToConn[cid] = conn
+	}
+
+	closedDevice := "A"
+	cm.CloseConnsForDevice(alice, closedDevice)
+	time.Sleep(100 * time.Millisecond) // some stuff happens asyncly in goroutines
+
+	// Destroy should have been called for all alice|A connections
+	assertDestroyedConns(t, cidToConn, func(cid ConnID) bool {
+		return cid.UserID == alice && cid.DeviceID == "A"
+	})
+}
+
+func TestConnMap_CloseConnsForUser(t *testing.T) {
+	cm := NewConnMap(false, time.Minute)
+	otherCID := ConnID{UserID: bob, DeviceID: "A", CID: "room-list"}
+	cidToConn := map[ConnID]*Conn{
+		{UserID: alice, DeviceID: "A", CID: "room-list"}:     nil,
+		{UserID: alice, DeviceID: "A", CID: "encryption"}:    nil,
+		{UserID: alice, DeviceID: "A", CID: "notifications"}: nil,
+		{UserID: alice, DeviceID: "B", CID: "room-list"}:     nil,
+		{UserID: alice, DeviceID: "B", CID: "encryption"}:    nil,
+		{UserID: alice, DeviceID: "B", CID: "notifications"}: nil,
+		otherCID: nil,
+	}
+	for cid := range cidToConn {
+		_, cancel := context.WithCancel(context.Background())
+		conn := cm.CreateConn(cid, cancel, func() ConnHandler {
+			return &mockConnHandler{}
+		})
+		cidToConn[cid] = conn
+	}
+
+	num := cm.CloseConnsForUsers([]string{alice})
+	time.Sleep(100 * time.Millisecond) // some stuff happens asyncly in goroutines
+	must.Equal(t, num, 6, "unexpected number of closed conns")
+
+	// Destroy should have been called for all alice|A connections
+	assertDestroyedConns(t, cidToConn, func(cid ConnID) bool {
+		return cid.UserID == alice
+	})
+}
+
+func TestConnMap_TTLExpiry(t *testing.T) {
+	cm := NewConnMap(false, time.Second) // 1s expiry
+	expiredCIDs := []ConnID{
+		{UserID: alice, DeviceID: "A", CID: "room-list"},
+		{UserID: alice, DeviceID: "A", CID: "encryption"},
+		{UserID: alice, DeviceID: "A", CID: "notifications"},
+	}
+	cidToConn := map[ConnID]*Conn{}
+	for _, cid := range expiredCIDs {
+		_, cancel := context.WithCancel(context.Background())
+		conn := cm.CreateConn(cid, cancel, func() ConnHandler {
+			return &mockConnHandler{}
+		})
+		cidToConn[cid] = conn
+	}
+	time.Sleep(time.Millisecond * 500)
+
+	unexpiredCIDs := []ConnID{
+		{UserID: alice, DeviceID: "B", CID: "room-list"},
+		{UserID: alice, DeviceID: "B", CID: "encryption"},
+		{UserID: alice, DeviceID: "B", CID: "notifications"},
+	}
+	for _, cid := range unexpiredCIDs {
+		_, cancel := context.WithCancel(context.Background())
+		conn := cm.CreateConn(cid, cancel, func() ConnHandler {
+			return &mockConnHandler{}
+		})
+		cidToConn[cid] = conn
+	}
+
+	time.Sleep(510 * time.Millisecond) // all 'A' device conns must have expired
+
+	// Destroy should have been called for all alice|A connections
+	assertDestroyedConns(t, cidToConn, func(cid ConnID) bool {
+		return cid.DeviceID == "A"
+	})
+}
+
+func assertDestroyedConns(t *testing.T, cidToConn map[ConnID]*Conn, isDestroyedFn func(cid ConnID) bool) {
+	t.Helper()
+	for cid, conn := range cidToConn {
+		if isDestroyedFn(cid) {
+			must.Equal(t, conn.handler.(*mockConnHandler).isDestroyed, true, fmt.Sprintf("conn %+v was not destroyed", cid))
+		} else {
+			must.Equal(t, conn.handler.(*mockConnHandler).isDestroyed, false, fmt.Sprintf("conn %+v was destroyed", cid))
+		}
+	}
+}
+
+type mockConnHandler struct {
+	isDestroyed bool
+	cancel      context.CancelFunc
+}
+
+func (c *mockConnHandler) OnIncomingRequest(ctx context.Context, cid ConnID, req *Request, isInitial bool, start time.Time) (*Response, error) {
+	return nil, nil
+}
+func (c *mockConnHandler) OnUpdate(ctx context.Context, update caches.Update) {}
+func (c *mockConnHandler) PublishEventsUpTo(roomID string, nid int64)         {}
+func (c *mockConnHandler) Destroy() {
+	c.isDestroyed = true
+}
+func (c *mockConnHandler) Alive() bool {
+	return true // buffer never fills up
+}
+func (c *mockConnHandler) SetCancelCallback(cancel context.CancelFunc) {
+	c.cancel = cancel
+}


### PR DESCRIPTION
- Connections are unique for the 3-uple (user, device, conneciton) IDs.
  The code was only checking (user, device). This means we would delete
  ALL connections for a device, is ANY connection expired.
- ...except we wouldn't, because of the 2nd bug, which is the deletion
  code itself. This is missing `i--` so we will not do an ID check on
  the element after a deleted index.

Both of these bugs have been fixed.

This fixes a critical issue whereby a connection could suddenly stop receiving live updates if:
 - the device has >1 active connection
 - one of those connections expires but not the other.

If both of these are true, the expired connection will take out the unexpired connection with it. This will remove both connections from the map `userIDToConn` in `ConnMap`. At this point, the unexpired connection is still in the ttlcache.
Incoming requests _only query the ttlcache_, so we won't be aware that the connection is not in the `userIDToConn` map. This will actually have no end-user visible bugs... until something tries to figure out which connections are active for this user. Such as....
 - `OnInvalidateRoom`: this tears down all connections and the user cache. Except it won't tear down the unexpired connection because it relies on `userIDToConn` for figuring out which connections are active. This leads to zombie connections which receive no live updates. This manifest as seeing no new messages for rooms, despite getting 200 OKs back promptly.
 - `OnDeviceData` and `OnDeviceMessages`: both of these rely on the `userIDToConn` map to figure out which connections to wake up for the device-specific information. This will impact the delivery of to-device messages, and timeline updates of OTK counts and hence could affect encryption on EX, specifically making it take longer to establish Olm sessions, and seeing "unable to decrypt" errors for longer. At no point is data _lost_, only delayed.
 - `OnExpiredToken`: this relies on `userIDToConn` for closing connections. This means a connection will not be closed when it should be when the token expires, causing a form of zombie connection, as we don't check if a connection is "active" all the time, relying on this callback to know when to stop servicing the access token.
 - `OnTransactionID`: this relies on `userIDToConn` for sending `ClearUpdateQueues` to flush locally sent events. If the connection is missing, this would cause local events to block the update queue for `MaxTransactionIDDelay` (1s) every single time the user sends a message.