### PR TITLE
WIP: only emit avatars when the DM flag is set

### DIFF
--- a/internal/roomname.go
+++ b/internal/roomname.go
@@ -258,18 +258,3 @@ func disambiguate(heroes []Hero) []string {
 	}
 	return disambiguatedNames
 }
-
-const noAvatar = ""
-
-// CalculateAvatar computes the avatar for the room, based on the global room metadata.
-// Assumption: metadata.RemoveHero has been called to remove the user who is syncing
-// from the list of heroes.
-func CalculateAvatar(metadata *RoomMetadata) string {
-	if metadata.AvatarEvent != "" {
-		return metadata.AvatarEvent
-	}
-	if len(metadata.Heroes) == 1 {
-		return metadata.Heroes[0].Avatar
-	}
-	return noAvatar
-}

--- a/sync3/avatar.go
+++ b/sync3/avatar.go
@@ -3,6 +3,8 @@ package sync3
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/matrix-org/sliding-sync/internal"
+	"github.com/matrix-org/sliding-sync/sync3/caches"
 )
 
 // An AvatarChange represents a change to a room's avatar. There are three cases:
@@ -40,3 +42,17 @@ func (a *AvatarChange) UnmarshalJSON(data []byte) error {
 	}
 	return json.Unmarshal(data, (*string)(a))
 }
+
+// CalculateAvatar computes the avatar for the room as seen by a given user.
+// It does not the given RoomConnMetadata struct.
+func CalculateAvatar(globalMetadata *internal.RoomMetadata, userMetadata *caches.UserRoomData) string {
+	if globalMetadata.AvatarEvent != "" {
+		return globalMetadata.AvatarEvent
+	}
+	if userMetadata.IsDM && len(globalMetadata.Heroes) == 1 {
+		return globalMetadata.Heroes[0].Avatar
+	}
+	return noAvatar
+}
+
+const noAvatar = ""

--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -52,6 +52,7 @@ type UserRoomData struct {
 	// Avatars set in m.room.avatar take precedence; if this is missing and the room is
 	// a DM with one other user joined or invited, we fall back to that user's
 	// avatar (if any) as specified in their membership event in that room.
+	// XXX: this field appears to be write-only?!!?
 	ResolvedAvatarURL string
 
 	// Spaces is the set of room IDs of spaces that this room is part of.

--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -111,7 +111,7 @@ func NewInviteData(ctx context.Context, userID, roomID string, inviteState []jso
 					Timestamp:     uint64(ts),
 					AlwaysProcess: true,
 				}
-				id.IsDM = j.Get("is_direct").Bool()
+				id.IsDM = j.Get("content.is_direct").Bool()
 			} else if target == j.Get("sender").Str {
 				id.Heroes = append(id.Heroes, internal.Hero{
 					ID:     target,

--- a/sync3/handler/connstate.go
+++ b/sync3/handler/connstate.go
@@ -675,7 +675,7 @@ func (s *ConnState) getInitialRoomData(ctx context.Context, roomSub sync3.RoomSu
 		roomName, calculated := internal.CalculateRoomName(metadata, 5) // TODO: customisable?
 		room := sync3.Room{
 			Name:              roomName,
-			AvatarChange:      sync3.NewAvatarChange(internal.CalculateAvatar(metadata)),
+			AvatarChange:      sync3.NewAvatarChange(sync3.CalculateAvatar(metadata, &userRoomData)),
 			NotificationCount: int64(userRoomData.NotificationCount),
 			HighlightCount:    int64(userRoomData.HighlightCount),
 			Timeline:          roomToTimeline[roomID],

--- a/sync3/handler/connstate_live.go
+++ b/sync3/handler/connstate_live.go
@@ -277,7 +277,8 @@ func (s *connStateLive) processLiveUpdate(ctx context.Context, up caches.Update,
 			if delta.RoomAvatarChanged {
 				metadata := roomUpdate.GlobalRoomMetadata()
 				metadata.RemoveHero(s.userID)
-				thisRoom.AvatarChange = sync3.NewAvatarChange(internal.CalculateAvatar(metadata))
+				userRoomData := roomUpdate.UserRoomMetadata()
+				thisRoom.AvatarChange = sync3.NewAvatarChange(sync3.CalculateAvatar(metadata, userRoomData))
 			}
 			if delta.InviteCountChanged {
 				thisRoom.InvitedCount = &roomUpdate.GlobalRoomMetadata().InviteCount

--- a/sync3/lists.go
+++ b/sync3/lists.go
@@ -87,7 +87,7 @@ func (s *InternalRequestLists) SetRoom(r RoomConnMetadata) (delta RoomDelta) {
 		}
 		delta.RoomAvatarChanged = !existing.SameRoomAvatar(&r.RoomMetadata)
 		if delta.RoomAvatarChanged {
-			r.ResolvedAvatarURL = internal.CalculateAvatar(&r.RoomMetadata)
+			r.ResolvedAvatarURL = CalculateAvatar(&r.RoomMetadata, &r.UserRoomData)
 		}
 
 		// Interpret the timestamp map on r as the changes we should apply atop the
@@ -114,7 +114,7 @@ func (s *InternalRequestLists) SetRoom(r RoomConnMetadata) (delta RoomDelta) {
 		r.CanonicalisedName = strings.ToLower(
 			strings.Trim(roomName, "#!():_@"),
 		)
-		r.ResolvedAvatarURL = internal.CalculateAvatar(&r.RoomMetadata)
+		r.ResolvedAvatarURL = CalculateAvatar(&r.RoomMetadata, &r.UserRoomData)
 		// We'll automatically use the LastInterestedEventTimestamps provided by the
 		// caller, so that recency sorts work.
 	}

--- a/tests-e2e/lists_test.go
+++ b/tests-e2e/lists_test.go
@@ -1652,6 +1652,7 @@ func TestAvatarFieldInRoomResponse(t *testing.T) {
 	})
 
 	t.Run("Changing DM flag", func(t *testing.T) {
+		// XXX: the test's expectations might very well be out of date now
 		t.Skip("TODO: unimplemented")
 		t.Log("Alice clears the DM flag on Bob's room.")
 		alice.MustSetGlobalAccountData(t, "m.direct", map[string]interface{}{

--- a/testutils/m/match.go
+++ b/testutils/m/match.go
@@ -694,6 +694,15 @@ func MatchNoRoomAccountData(roomIDs []string) RespMatcher {
 	}
 }
 
+func MatchRoomIsDM(wantDM bool) RoomMatcher {
+	return func(r sync3.Room) error {
+		if r.IsDM != wantDM {
+			return fmt.Errorf("MatchRoomIsDM: got %t want %t", r.IsDM, wantDM)
+		}
+		return nil
+	}
+}
+
 // LogResponse builds a matcher that always succeeds. As a side-effect, it pretty-prints
 // the given sync response to the test log. This is useful when debugging a test.
 func LogResponse(t *testing.T) RespMatcher {


### PR DESCRIPTION
C.f. https://github.com/vector-im/element-x-ios/issues/2003#issuecomment-1840438661

I don't think this works yet because clients have to set the DM flag after they see the room down /sync. And the proxy probably doesn't recalculate avatars after the DM flag changes.

More generally there's a lot here that's confusing and I don't really like this code.