### PR TITLE
Fix unix socket permissions

### DIFF
--- a/v3.go
+++ b/v3.go
@@ -248,7 +248,8 @@ func unixSocketListener(bindAddr string) net.Listener {
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to serve unix socket")
 	}
-	// User of web server needs to belong to group 'synv3' (-w--w----), could be extracted as env variable if needed
+	// User of web server needs to belong to the group of 'syncv3' (-w--w----); could be
+	// extracted as env variable if needed
 	err = os.Chmod(bindAddr, 0220)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to set unix socket permissions")

--- a/v3.go
+++ b/v3.go
@@ -249,7 +249,7 @@ func unixSocketListener(bindAddr string) net.Listener {
 		logger.Fatal().Err(err).Msg("failed to serve unix socket")
 	}
 	// TODO: safe default for now (rwxr-xr-x), could be extracted as env variable if needed
-	err = os.Chmod(bindAddr, 0755)
+	err = os.Chmod(bindAddr, 0220)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to set unix socket permissions")
 	}

--- a/v3.go
+++ b/v3.go
@@ -248,7 +248,7 @@ func unixSocketListener(bindAddr string) net.Listener {
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to serve unix socket")
 	}
-	// TODO: safe default for now (rwxr-xr-x), could be extracted as env variable if needed
+	// User of web server needs to belong to group 'synv3' (-w--w----), could be extracted as env variable if needed
 	err = os.Chmod(bindAddr, 0220)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to set unix socket permissions")

--- a/v3.go
+++ b/v3.go
@@ -248,9 +248,9 @@ func unixSocketListener(bindAddr string) net.Listener {
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to serve unix socket")
 	}
-	// User of web server needs to belong to the group of 'syncv3' (-w--w----); could be
-	// extracted as env variable if needed
-	err = os.Chmod(bindAddr, 0220)
+	// least permissions and work out of box (-w--w--w-); could be extracted as
+	// env variable if needed
+	err = os.Chmod(bindAddr, 0222)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to set unix socket permissions")
 	}


### PR DESCRIPTION
Discussions here: https://github.com/matrix-org/sliding-sync/pull/378#discussion_r1400713372.

I’ve gone with `0222` for now, as a nod to Caddy. For comparison, neither mysql nor postgres considers `0777` as posing a security risk.

I’m also fine with `0660` or `0220`, but that’d require assigning the user of web server to the group of syncv3 in a reverse-proxy context.

I’ll do a sign-off with the foundation if you decide to merge this.