### PR TITLE
CGO disabled to allow running on older distros

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       - run: mkdir build
       - run: go build -trimpath -o build/syncv3_${{ matrix.os }}_${{ matrix.arch }} ./cmd/syncv3
         env:
+          CGO_ENABLED: 0
           GOOS: ${{ matrix.os }}
           GOARCH: ${{ matrix.arch }}
       - name: "Upload binary as artifact"

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ location /.well-known/matrix/client {
 There are two ways to run the proxy:
 - Compiling from source:
 ```
-$ go build ./cmd/syncv3
+$ CGO_ENABLED=0 go build ./cmd/syncv3
 $ SYNCV3_SECRET=$(cat .secret) SYNCV3_SERVER="https://matrix-client.matrix.org" SYNCV3_DB="user=$(whoami) dbname=syncv3 sslmode=disable password='DATABASE_PASSWORD_HERE'" SYNCV3_BINDADDR=0.0.0.0:8008 ./syncv3
 ```
 
@@ -192,7 +192,7 @@ Then send `profile.pprof` to someone who will then run `go tool pprof -http :565
 Sanity check everything builds:
 
 ```shell
-go build ./cmd/syncv3
+CGO_ENABLED=0 go build ./cmd/syncv3
 go list ./... | xargs -n1 go test -c -o /dev/null
 ```
 


### PR DESCRIPTION
with CGO we are linking to whatever glibc is in ubuntu-latest, which may
not be present in other distros (Think older Debian, Alpine)

In addition, the docker build with alpine already (implicitly) does not
use CGO, as CGO is still not supported with musl officially if I
understand the following issue correctly: https://github.com/golang/go/issues/19938

So disabling CGO in the released binaries and in the README instructions harmonizes
the behaviour across docker and non-docker builds.

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

Signed-off-by: Christoph Settgast <csett86_git@quicksands.de>