### PR TITLE
Add more spans for live updates; change when we early return from buffered events

### DIFF
--- a/sync3/caches/user.go
+++ b/sync3/caches/user.go
@@ -428,7 +428,9 @@ func (c *UserCache) Invites() map[string]UserRoomData {
 }
 
 // AttemptToFetchPrevBatch tries to find a prev_batch value for the given event. This may not always succeed.
-func (c *UserCache) AttemptToFetchPrevBatch(roomID string, firstTimelineEvent *EventData) (prevBatch string) {
+func (c *UserCache) AttemptToFetchPrevBatch(ctx context.Context, roomID string, firstTimelineEvent *EventData) (prevBatch string) {
+	_, span := internal.StartSpan(ctx, "AttemptToFetchPrevBatch")
+	defer span.End()
 	return c.store.GetClosestPrevBatch(roomID, firstTimelineEvent.NID)
 }
 

--- a/sync3/extensions/extensions.go
+++ b/sync3/extensions/extensions.go
@@ -318,7 +318,9 @@ func (h *Handler) HandleLiveUpdate(ctx context.Context, update caches.Update, re
 	extCtx.Handler = h
 	exts := req.EnabledExtensions()
 	for _, ext := range exts {
-		ext.AppendLive(ctx, res, extCtx, update)
+		childCtx, region := internal.StartSpan(ctx, "extension_live_"+ext.Name())
+		ext.AppendLive(childCtx, res, extCtx, update)
+		region.End()
 	}
 }
 


### PR DESCRIPTION
- Add more spans to live updates to account for more time spent in various functions.
- When there are a lot of stacked updates in the buffer, return after processing 100 of them rather than relying on >=50 list operations. List operations isn't a good proxy for the amount of work being done, as the majority of work updates are things like: receipts, typing, device list updates. This means we will return faster than before when we have stacked updates, reducing perceived latency, despite having to still go through the entire buffer.


