### PR TITLE
bugfix: ensure sentry username/id values are correct

### DIFF
--- a/sync2/poller.go
+++ b/sync2/poller.go
@@ -503,10 +503,7 @@ func (p *poller) Poll(since string) {
 	// caller and passed down?
 	hub := sentry.CurrentHub().Clone()
 	hub.ConfigureScope(func(scope *sentry.Scope) {
-		scope.SetUser(sentry.User{Username: p.userID})
-		scope.SetContext(internal.SentryCtxKey, map[string]interface{}{
-			"device_id": p.deviceID,
-		})
+		scope.SetUser(sentry.User{Username: p.userID, ID: p.deviceID})
 	})
 	ctx := sentry.SetHubOnContext(context.Background(), hub)
 

--- a/sync3/handler/handler.go
+++ b/sync3/handler/handler.go
@@ -385,7 +385,7 @@ func (h *SyncLiveHandler) setupConnection(req *http.Request, cancel context.Canc
 		Str("device", token.DeviceID).
 		Str("conn", syncReq.ConnID).
 		Logger()
-	internal.SetRequestContextUserID(req.Context(), token.UserID, token.DeviceID)
+	req = req.WithContext(internal.AssociateUserIDWithRequest(req.Context(), token.UserID, token.DeviceID))
 	internal.Logf(req.Context(), "setupConnection", "identified access token as user=%s device=%s", token.UserID, token.DeviceID)
 
 	// Record the fact that we've recieved a request from this token


### PR DESCRIPTION
Previously there were wrong under high concurrency due to using the global hub instead of a per-request hub.