### PR TITLE
Support non-colorized log output, logging refactor

### DIFF
--- a/internal/errors.go
+++ b/internal/errors.go
@@ -8,14 +8,8 @@ import (
 	"runtime"
 
 	"github.com/getsentry/sentry-go"
-
-	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
-
-var logger = zerolog.New(os.Stdout).With().Timestamp().Logger().Output(zerolog.ConsoleWriter{
-	Out:        os.Stderr,
-	TimeFormat: "15:04:05",
-})
 
 type HandlerError struct {
 	StatusCode int
@@ -103,7 +97,7 @@ func assert(msg string, expr bool) {
 	if os.Getenv("SYNCV3_DEBUG") == "1" {
 		panic(fmt.Sprintf("assert: %s", msg))
 	}
-	l := logger.Error()
+	l := log.Error()
 	_, file, line, ok := runtime.Caller(1)
 	if ok {
 		l = l.Str("assertion", fmt.Sprintf("%s:%d", file, line))

--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -2,18 +2,11 @@ package pubsub
 
 import (
 	"fmt"
-	"os"
 	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/rs/zerolog"
 )
-
-var logger = zerolog.New(os.Stdout).With().Timestamp().Logger().Output(zerolog.ConsoleWriter{
-	Out:        os.Stderr,
-	TimeFormat: "15:04:05",
-})
 
 type Payload interface {
 	// The type of payload; used mostly for logging and prometheus metrics

--- a/pubsub/v2.go
+++ b/pubsub/v2.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/matrix-org/sliding-sync/internal"
+	"github.com/rs/zerolog/log"
 )
 
 // The channel which has V2* payloads
@@ -197,7 +198,7 @@ func (v *V2Sub) onMessage(p Payload) {
 	case *V2StateRedaction:
 		v.receiver.OnStateRedaction(pl)
 	default:
-		logger.Warn().Str("type", p.Type()).Msg("V2Sub: unhandled payload type")
+		log.Warn().Str("type", p.Type()).Msg("V2Sub: unhandled payload type")
 	}
 }
 

--- a/pubsub/v3.go
+++ b/pubsub/v3.go
@@ -1,5 +1,9 @@
 package pubsub
 
+import (
+	"github.com/rs/zerolog/log"
+)
+
 // The channel which has V3* payloads
 const ChanV3 = "v3ch"
 
@@ -39,7 +43,7 @@ func (v *V3Sub) onMessage(p Payload) {
 	case *V3EnsurePolling:
 		v.receiver.EnsurePolling(pl)
 	default:
-		logger.Warn().Str("type", p.Type()).Msg("V3Sub: unhandled payload type")
+		log.Warn().Str("type", p.Type()).Msg("V3Sub: unhandled payload type")
 	}
 }
 

--- a/state/event_table.go
+++ b/state/event_table.go
@@ -14,6 +14,7 @@ import (
 	"github.com/matrix-org/gomatrixserverlib"
 	"github.com/matrix-org/sliding-sync/internal"
 	"github.com/matrix-org/sliding-sync/sqlutil"
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -393,7 +394,7 @@ func (t *EventTable) Redact(txn *sqlx.Tx, roomVer string, redacteeEventIDToRedac
 	if err != nil {
 		// unknown room version... let's just default to "1"
 		rv = gomatrixserverlib.MustGetRoomVersion(gomatrixserverlib.RoomVersionV1)
-		logger.Warn().Str("version", roomVer).Err(err).Msg(
+		log.Warn().Str("version", roomVer).Err(err).Msg(
 			"Redact: GetRoomVersion: unknown room version, defaulting to v1",
 		)
 	}
@@ -567,7 +568,7 @@ func filterAndEnsureFieldsSet(events []Event) []Event {
 	for i := range events {
 		ev := &events[i]
 		if err := ev.ensureFieldsSetOnEvent(); err != nil {
-			logger.Warn().Str("event_id", ev.ID).Err(err).Msg(
+			log.Warn().Str("event_id", ev.ID).Err(err).Msg(
 				"filterAndEnsureFieldsSet: failed to parse event, ignoring",
 			)
 			continue

--- a/state/migrations/20230822180807_bogus_snapshot_cleanup.go
+++ b/state/migrations/20230822180807_bogus_snapshot_cleanup.go
@@ -4,16 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+
 	"github.com/lib/pq"
 	"github.com/pressly/goose/v3"
-	"github.com/rs/zerolog"
-	"os"
+	"github.com/rs/zerolog/log"
 )
-
-var logger = zerolog.New(os.Stdout).With().Timestamp().Logger().Output(zerolog.ConsoleWriter{
-	Out:        os.Stderr,
-	TimeFormat: "15:04:05",
-})
 
 func init() {
 	goose.AddMigrationContext(upBogusSnapshotCleanup, downBogusSnapshotCleanup)
@@ -29,7 +24,7 @@ func upBogusSnapshotCleanup(ctx context.Context, tx *sql.Tx) error {
 	if len(bogusRooms) == 0 {
 		return nil
 	}
-	logger.Info().Strs("room_ids", bogusRooms).
+	log.Info().Strs("room_ids", bogusRooms).
 		Msgf("Found %d bogus rooms to cleanup", len(bogusRooms))
 
 	tables := []string{"syncv3_snapshots", "syncv3_events", "syncv3_rooms"}
@@ -52,9 +47,9 @@ func deleteFromTable(ctx context.Context, tx *sql.Tx, table string, roomIDs []st
 	}
 	ra, err := result.RowsAffected()
 	if err != nil {
-		logger.Warn().Err(err).Msgf("Couldn't get number of rows deleted from %s", table)
+		log.Warn().Err(err).Msgf("Couldn't get number of rows deleted from %s", table)
 	} else {
-		logger.Info().Msgf("Deleted %d rows from %s", ra, table)
+		log.Info().Msgf("Deleted %d rows from %s", ra, table)
 	}
 	return nil
 }

--- a/state/migrations/20231108122539_clear_stuck_invites.go
+++ b/state/migrations/20231108122539_clear_stuck_invites.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/pressly/goose/v3"
+	"github.com/rs/zerolog/log"
 )
 
 func init() {
@@ -49,9 +50,9 @@ func upClearStuckInvites(ctx context.Context, tx *sql.Tx) error {
 		}
 		usersToInvalidate = append(usersToInvalidate, userID)
 	}
-	logger.Info().Int("len_invalidate_users", len(usersToInvalidate)).Msg("invalidating users")
+	log.Info().Int("len_invalidate_users", len(usersToInvalidate)).Msg("invalidating users")
 	if len(usersToInvalidate) < 50 {
-		logger.Info().Strs("invalidate_users", usersToInvalidate).Msg("invalidating users")
+		log.Info().Strs("invalidate_users", usersToInvalidate).Msg("invalidating users")
 	}
 
 	// for each user:
@@ -64,7 +65,7 @@ func upClearStuckInvites(ctx context.Context, tx *sql.Tx) error {
 		return fmt.Errorf("failed to invalidate since tokens: %w", err)
 	}
 	ra, _ := res.RowsAffected()
-	logger.Info().Int64("num_devices", ra).Msg("reset since tokens")
+	log.Info().Int64("num_devices", ra).Msg("reset since tokens")
 
 	res, err = tx.ExecContext(ctx, `
 	DELETE FROM syncv3_invites WHERE user_id=ANY($1)
@@ -73,7 +74,7 @@ func upClearStuckInvites(ctx context.Context, tx *sql.Tx) error {
 		return fmt.Errorf("failed to remove outstanding invites: %w", err)
 	}
 	ra, _ = res.RowsAffected()
-	logger.Info().Int64("num_invites", ra).Msg("reset invites")
+	log.Info().Int64("num_invites", ra).Msg("reset invites")
 	return nil
 }
 

--- a/state/migrations/20240517104423_device_list_table.go
+++ b/state/migrations/20240517104423_device_list_table.go
@@ -12,6 +12,7 @@ import (
 	"github.com/matrix-org/sliding-sync/sqlutil"
 	"github.com/matrix-org/sliding-sync/state"
 	"github.com/pressly/goose/v3"
+	"github.com/rs/zerolog/log"
 )
 
 type OldDeviceData struct {
@@ -63,7 +64,7 @@ func upDeviceListTable(ctx context.Context, tx *sql.Tx) error {
 	if err = tx.QueryRow(`SELECT count(*) FROM syncv3_device_data`).Scan(&count); err != nil {
 		return err
 	}
-	logger.Info().Int("count", count).Msg("transferring device list data for devices")
+	log.Info().Int("count", count).Msg("transferring device list data for devices")
 
 	// scan for existing CBOR (streaming as the CBOR with cursors as it can be large)
 	_, err = tx.Exec(`DECLARE device_data_migration_cursor CURSOR FOR SELECT user_id, device_id, data FROM syncv3_device_data`)
@@ -82,7 +83,7 @@ func upDeviceListTable(ctx context.Context, tx *sql.Tx) error {
 		// logging
 		i++
 		if time.Since(lastUpdate) > updateFrequency {
-			logger.Info().Msgf("%d/%d process device list data", i, count)
+			log.Info().Msgf("%d/%d process device list data", i, count)
 			lastUpdate = time.Now()
 		}
 

--- a/state/to_device_table.go
+++ b/state/to_device_table.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
 	"github.com/matrix-org/sliding-sync/sqlutil"
+	"github.com/rs/zerolog/log"
 	"github.com/tidwall/gjson"
 )
 
@@ -109,7 +110,7 @@ func (t *ToDeviceTable) Messages(userID, deviceID string, from, limit int64) (ms
 		m := gjson.ParseBytes(msgs[i])
 		msgId := m.Get(`content.org\.matrix\.msgid`).Str
 		if msgId != "" {
-			logger.Info().Str("msgid", msgId).Str("user", userID).Str("device", deviceID).Msg("ToDeviceTable.Messages")
+			log.Info().Str("msgid", msgId).Str("user", userID).Str("device", deviceID).Msg("ToDeviceTable.Messages")
 		}
 	}
 	upTo = rows[len(rows)-1].Position
@@ -143,7 +144,7 @@ func (t *ToDeviceTable) InsertMessages(userID, deviceID string, msgs []json.RawM
 			}
 			msgId := m.Get(`content.org\.matrix\.msgid`).Str
 			if msgId != "" {
-				logger.Debug().Str("msgid", msgId).Str("user", userID).Str("device", deviceID).Msg("ToDeviceTable.InsertMessages")
+				log.Debug().Str("msgid", msgId).Str("user", userID).Str("device", deviceID).Msg("ToDeviceTable.InsertMessages")
 			}
 			switch rows[i].Type {
 			case "m.room_key_request":

--- a/sync2/handler2/handler_test.go
+++ b/sync2/handler2/handler_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/matrix-org/sliding-sync/sync2"
 	"github.com/matrix-org/sliding-sync/sync2/handler2"
 	"github.com/matrix-org/sliding-sync/testutils"
-	"github.com/rs/zerolog"
 )
 
 var postgresURI string
@@ -52,7 +51,7 @@ func (p *mockPollerMap) ExpirePollers([]sync2.PollerID) int {
 	return 0
 }
 
-func (p *mockPollerMap) EnsurePolling(pid sync2.PollerID, accessToken, v2since string, isStartup bool, logger zerolog.Logger) (bool, error) {
+func (p *mockPollerMap) EnsurePolling(pid sync2.PollerID, accessToken, v2since string, isStartup bool) (bool, error) {
 	p.calls = append(p.calls, pollInfo{
 		pid:         pid,
 		accessToken: accessToken,

--- a/sync2/storage.go
+++ b/sync2/storage.go
@@ -1,17 +1,10 @@
 package sync2
 
 import (
-	"os"
-
 	"github.com/getsentry/sentry-go"
 	"github.com/jmoiron/sqlx"
-	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
-
-var logger = zerolog.New(os.Stdout).With().Timestamp().Logger().Output(zerolog.ConsoleWriter{
-	Out:        os.Stderr,
-	TimeFormat: "15:04:05",
-})
 
 type Storage struct {
 	DevicesTable *DevicesTable
@@ -24,7 +17,7 @@ func NewStore(postgresURI, secret string) *Storage {
 	if err != nil {
 		sentry.CaptureException(err)
 		// TODO: if we panic(), will sentry have a chance to flush the event?
-		logger.Panic().Err(err).Str("uri", postgresURI).Msg("failed to open SQL DB")
+		log.Panic().Err(err).Str("uri", postgresURI).Msg("failed to open SQL DB")
 	}
 	return NewStoreWithDB(db, secret)
 }

--- a/sync2/tokens_table.go
+++ b/sync2/tokens_table.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"github.com/jmoiron/sqlx"
+	"github.com/rs/zerolog/log"
 	"io"
 	"strings"
 	"time"
@@ -254,7 +255,7 @@ func (t *TokensTable) Delete(accessTokenHash string) error {
 		return err
 	}
 	if ra != 1 {
-		logger.Warn().Msgf("Tokens.Delete: expected to delete one token, but actually deleted %d", ra)
+		log.Warn().Msgf("Tokens.Delete: expected to delete one token, but actually deleted %d", ra)
 	}
 	return nil
 }

--- a/sync3/dispatcher.go
+++ b/sync3/dispatcher.go
@@ -3,19 +3,13 @@ package sync3
 import (
 	"context"
 	"encoding/json"
-	"os"
 	"sync"
 
 	"github.com/matrix-org/sliding-sync/internal"
 	"github.com/matrix-org/sliding-sync/sync3/caches"
-	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/tidwall/gjson"
 )
-
-var logger = zerolog.New(os.Stdout).With().Timestamp().Logger().Output(zerolog.ConsoleWriter{
-	Out:        os.Stderr,
-	TimeFormat: "15:04:05",
-})
 
 const DispatcherAllUsers = "-"
 
@@ -83,7 +77,7 @@ func (d *Dispatcher) Register(ctx context.Context, userID string, r Receiver) er
 	d.userToReceiverMu.Lock()
 	defer d.userToReceiverMu.Unlock()
 	if _, ok := d.userToReceiver[userID]; ok {
-		logger.Warn().Str("user", userID).Msg("Dispatcher.Register: receiver already registered")
+		log.Warn().Str("user", userID).Msg("Dispatcher.Register: receiver already registered")
 	}
 	d.userToReceiver[userID] = r
 	return r.OnRegistered(ctx)
@@ -122,7 +116,7 @@ func (d *Dispatcher) newEventData(event json.RawMessage, roomID string, latestPo
 func (d *Dispatcher) OnNewInitialRoomState(ctx context.Context, roomID string, state []json.RawMessage) {
 	// sanity check
 	if _, jc := d.jrt.JoinedUsersForRoom(roomID, nil); jc > 0 {
-		logger.Warn().Int("join_count", jc).Str("room", roomID).Int("num_state", len(state)).Msg(
+		log.Warn().Int("join_count", jc).Str("room", roomID).Int("num_state", len(state)).Msg(
 			"OnNewInitialRoomState but have entries in JoinedRoomsTracker already, this should be impossible. Degrading to live events",
 		)
 		for _, s := range state {

--- a/sync3/extensions/account_data.go
+++ b/sync3/extensions/account_data.go
@@ -7,6 +7,7 @@ import (
 	"github.com/matrix-org/sliding-sync/internal"
 	"github.com/matrix-org/sliding-sync/state"
 	"github.com/matrix-org/sliding-sync/sync3/caches"
+	"github.com/rs/zerolog/log"
 )
 
 // Client created request params
@@ -66,7 +67,7 @@ func (r *AccountDataRequest) AppendLive(ctx context.Context, res *Response, extC
 			}
 			roomAccountData, err := extCtx.Store.AccountDatas(extCtx.UserID, update.RoomID())
 			if err != nil {
-				logger.Err(err).Str("user", extCtx.UserID).Str("room", update.RoomID()).Msg("failed to fetch room account data")
+				log.Err(err).Str("user", extCtx.UserID).Str("room", update.RoomID()).Msg("failed to fetch room account data")
 				internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(err)
 			} else {
 				if len(roomAccountData) > 0 { // else we can end up with `null` not `[]`
@@ -109,7 +110,7 @@ func (r *AccountDataRequest) ProcessInitial(ctx context.Context, res *Response, 
 	if len(roomIDs) > 0 {
 		roomsAccountData, err := extCtx.Store.AccountDatas(extCtx.UserID, roomIDs...)
 		if err != nil {
-			logger.Err(err).Str("user", extCtx.UserID).Strs("rooms", roomIDs).Msg("failed to fetch room account data")
+			log.Err(err).Str("user", extCtx.UserID).Strs("rooms", roomIDs).Msg("failed to fetch room account data")
 			internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(err)
 		} else {
 			extRes.Rooms = make(map[string][]json.RawMessage)
@@ -123,7 +124,7 @@ func (r *AccountDataRequest) ProcessInitial(ctx context.Context, res *Response, 
 	if extCtx.IsInitial {
 		globalAccountData, err := extCtx.Store.AccountDatas(extCtx.UserID)
 		if err != nil {
-			logger.Err(err).Str("user", extCtx.UserID).Msg("failed to fetch global account data")
+			log.Err(err).Str("user", extCtx.UserID).Msg("failed to fetch global account data")
 			internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(err)
 		} else {
 			extRes.Global = accountEventsAsJSON(globalAccountData)

--- a/sync3/extensions/extensions.go
+++ b/sync3/extensions/extensions.go
@@ -3,19 +3,12 @@ package extensions
 
 import (
 	"context"
-	"os"
 	"reflect"
 
 	"github.com/matrix-org/sliding-sync/internal"
 	"github.com/matrix-org/sliding-sync/state"
 	"github.com/matrix-org/sliding-sync/sync3/caches"
-	"github.com/rs/zerolog"
 )
-
-var logger = zerolog.New(os.Stdout).With().Timestamp().Logger().Output(zerolog.ConsoleWriter{
-	Out:        os.Stderr,
-	TimeFormat: "15:04:05",
-})
 
 type GenericRequest interface {
 	// Name provides a name to identify the kind of request. At present, it's only

--- a/sync3/extensions/receipts.go
+++ b/sync3/extensions/receipts.go
@@ -7,6 +7,7 @@ import (
 	"github.com/matrix-org/sliding-sync/internal"
 	"github.com/matrix-org/sliding-sync/state"
 	"github.com/matrix-org/sliding-sync/sync3/caches"
+	"github.com/rs/zerolog/log"
 )
 
 // Client created request params
@@ -42,7 +43,7 @@ func (r *ReceiptsRequest) AppendLive(ctx context.Context, res *Response, extCtx 
 		if res.Receipts == nil {
 			edu, err := state.PackReceiptsIntoEDU([]internal.Receipt{update.Receipt})
 			if err != nil {
-				logger.Err(err).Str("user", extCtx.UserID).Str("room", update.Receipt.RoomID).Msg("failed to pack receipt into new edu")
+				log.Err(err).Str("user", extCtx.UserID).Str("room", update.Receipt.RoomID).Msg("failed to pack receipt into new edu")
 				internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(err)
 				return
 			}
@@ -55,7 +56,7 @@ func (r *ReceiptsRequest) AppendLive(ctx context.Context, res *Response, extCtx 
 			// we have receipts already, but not for this room
 			edu, err := state.PackReceiptsIntoEDU([]internal.Receipt{update.Receipt})
 			if err != nil {
-				logger.Err(err).Str("user", extCtx.UserID).Str("room", update.Receipt.RoomID).Msg("failed to pack receipt into edu")
+				log.Err(err).Str("user", extCtx.UserID).Str("room", update.Receipt.RoomID).Msg("failed to pack receipt into edu")
 				internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(err)
 				return
 			}
@@ -65,7 +66,7 @@ func (r *ReceiptsRequest) AppendLive(ctx context.Context, res *Response, extCtx 
 			// aggregate receipts: we need to unpack then repack annoyingly.
 			pub, priv, err := state.UnpackReceiptsFromEDU(update.RoomID(), res.Receipts.Rooms[update.RoomID()])
 			if err != nil {
-				logger.Err(err).Str("user", extCtx.UserID).Str("room", update.Receipt.RoomID).Msg("failed to pack receipt into edu")
+				log.Err(err).Str("user", extCtx.UserID).Str("room", update.Receipt.RoomID).Msg("failed to pack receipt into edu")
 				internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(err)
 				return
 			}
@@ -74,7 +75,7 @@ func (r *ReceiptsRequest) AppendLive(ctx context.Context, res *Response, extCtx 
 			receipts = append(receipts, update.Receipt)
 			edu, err := state.PackReceiptsIntoEDU(receipts)
 			if err != nil {
-				logger.Err(err).Str("user", extCtx.UserID).Str("room", update.Receipt.RoomID).Msg("failed to pack receipt into edu")
+				log.Err(err).Str("user", extCtx.UserID).Str("room", update.Receipt.RoomID).Msg("failed to pack receipt into edu")
 				internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(err)
 				return
 			}
@@ -94,7 +95,7 @@ func (r *ReceiptsRequest) ProcessInitial(ctx context.Context, res *Response, ext
 		}
 		receipts, err := extCtx.Store.ReceiptTable.SelectReceiptsForEvents(roomID, timeline)
 		if err != nil {
-			logger.Err(err).Str("user", extCtx.UserID).Str("room", roomID).Msg("failed to SelectReceiptsForEvents")
+			log.Err(err).Str("user", extCtx.UserID).Str("room", roomID).Msg("failed to SelectReceiptsForEvents")
 			internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(err)
 			continue
 		}
@@ -104,7 +105,7 @@ func (r *ReceiptsRequest) ProcessInitial(ctx context.Context, res *Response, ext
 	// single shot query to pull out our own receipts for these rooms to always include our own receipts
 	ownReceipts, err := extCtx.Store.ReceiptTable.SelectReceiptsForUser(interestedRoomIDs, extCtx.UserID)
 	if err != nil {
-		logger.Err(err).Str("user", extCtx.UserID).Strs("rooms", interestedRoomIDs).Msg("failed to SelectReceiptsForUser")
+		log.Err(err).Str("user", extCtx.UserID).Strs("rooms", interestedRoomIDs).Msg("failed to SelectReceiptsForUser")
 		internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(err)
 		return
 	}

--- a/sync3/extensions/todevice.go
+++ b/sync3/extensions/todevice.go
@@ -10,6 +10,7 @@ import (
 	"github.com/matrix-org/sliding-sync/internal"
 
 	"github.com/matrix-org/sliding-sync/sync3/caches"
+	"github.com/rs/zerolog/log"
 )
 
 // used to remember since positions to warn when they are not incremented. This can happen
@@ -64,7 +65,7 @@ func (r *ToDeviceRequest) ProcessInitial(ctx context.Context, res *Response, ext
 	if r.Limit == 0 {
 		r.Limit = 100 // default to 100
 	}
-	l := logger.With().Str("user", extCtx.UserID).Str("device", extCtx.DeviceID).Logger()
+	l := log.With().Str("user", extCtx.UserID).Str("device", extCtx.DeviceID).Logger()
 
 	mapMu.Lock()
 	lastSentPos, exists := deviceIDToSinceDebugOnly[extCtx.DeviceID]

--- a/sync3/handler/ensure_polling.go
+++ b/sync3/handler/ensure_polling.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/matrix-org/sliding-sync/pubsub"
+	"github.com/rs/zerolog/log"
 )
 
 // pendingInfo tracks the status of a poller that we are (or previously were) waiting
@@ -128,7 +129,7 @@ func (p *EnsurePoller) EnsurePolling(ctx context.Context, pid sync2.PollerID, to
 }
 
 func (p *EnsurePoller) OnInitialSyncComplete(payload *pubsub.V2InitialSyncComplete) {
-	log := logger.With().Str("user", payload.UserID).Str("device", payload.DeviceID).Logger()
+	log := log.With().Str("user", payload.UserID).Str("device", payload.DeviceID).Logger()
 	log.Trace().Msg("OnInitialSyncComplete: got payload")
 	pid := sync2.PollerID{UserID: payload.UserID, DeviceID: payload.DeviceID}
 	p.mu.Lock()

--- a/sync3/handler/rooms_builder.go
+++ b/sync3/handler/rooms_builder.go
@@ -13,19 +13,21 @@ import (
 // in the Response. It is not thread-safe and should only be called by the ConnState thread.
 //
 // The top-level `rooms` key is an amalgamation of:
-//  - Room subscriptions
-//  - Rooms within all sliding lists.
+//   - Room subscriptions
+//   - Rooms within all sliding lists.
 //
 // The purpose of this builder is to remember which rooms we will be returning data for, along with the
 // room subscription for that room. This then allows efficient database accesses. For example:
-//  - List A will return !a, !b, !c with Room Subscription X
-//  - List B will return !b, !c, !d with Room Subscription Y
-//  - Room sub for !a with Room Subscription Z
+//   - List A will return !a, !b, !c with Room Subscription X
+//   - List B will return !b, !c, !d with Room Subscription Y
+//   - Room sub for !a with Room Subscription Z
+//
 // Rather than performing each operation in isolation and query for rooms multiple times (where the
 // response data will inevitably be dropped), we can instead amalgamate this into:
-//  - Room Subscription X+Z -> !a
-//  - Room Subscription X+Y -> !b, !c
-//  - Room Subscription Y -> !d
+//   - Room Subscription X+Z -> !a
+//   - Room Subscription X+Y -> !b, !c
+//   - Room Subscription Y -> !d
+//
 // This data will not be wasted when it has been retrieved from the database.
 type RoomsBuilder struct {
 	subs       []sync3.RoomSubscription

--- a/sync3/lists.go
+++ b/sync3/lists.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/matrix-org/sliding-sync/internal"
+	"github.com/rs/zerolog/log"
 )
 
 type OverwriteVal bool
@@ -244,7 +245,7 @@ func (s *InternalRequestLists) AssignList(ctx context.Context, listKey string, f
 	if sort != nil {
 		err := roomList.Sort(sort)
 		if err != nil {
-			logger.Err(err).Strs("sort_by", sort).Msg("failed to sort")
+			log.Err(err).Strs("sort_by", sort).Msg("failed to sort")
 			internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(err)
 		}
 	}

--- a/sync3/main_test.go
+++ b/sync3/main_test.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/matrix-org/sliding-sync/testutils"
 	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 var postgresConnectionString = "user=xxxxx dbname=syncv3_test sslmode=disable"
 
 func TestMain(m *testing.M) {
-	logger = zerolog.New(os.Stdout).With().Timestamp().Logger().Output(zerolog.ConsoleWriter{
+	log.Logger = zerolog.New(os.Stdout).With().Timestamp().Logger().Output(zerolog.ConsoleWriter{
 		Out:        os.Stderr,
 		TimeFormat: "15:04:05",
 		NoColor:    true,

--- a/sync3/ops.go
+++ b/sync3/ops.go
@@ -3,6 +3,7 @@ package sync3
 import (
 	"context"
 	"github.com/matrix-org/sliding-sync/internal"
+	"github.com/rs/zerolog/log"
 )
 
 type List interface {
@@ -49,7 +50,7 @@ func CalculateListOps(ctx context.Context, reqList *RequestList, list List, room
 		list.Add(roomID)
 		// this should only move exactly 1 room at most as this is called for every single update
 		if err := list.Sort(reqList.Sort); err != nil {
-			logger.Err(err).Msg("cannot sort list")
+			log.Err(err).Msg("cannot sort list")
 			internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(err)
 		}
 		// find the new position of this room
@@ -67,7 +68,7 @@ func CalculateListOps(ctx context.Context, reqList *RequestList, list List, room
 	case ListOpChange:
 		// this should only move exactly 1 room at most as this is called for every single update
 		if err := list.Sort(reqList.Sort); err != nil {
-			logger.Err(err).Msg("cannot sort list")
+			log.Err(err).Msg("cannot sort list")
 			internal.GetSentryHubFromContextOrDefault(ctx).CaptureException(err)
 		}
 		// find the new position of this room

--- a/tests-e2e/gappy_state_test.go
+++ b/tests-e2e/gappy_state_test.go
@@ -69,11 +69,11 @@ func TestGappyState(t *testing.T) {
 	t.Log("Alice sends lots of other state events.")
 	const numOtherState = 40
 	for i := 0; i < numOtherState; i++ {
-    alice.Unsafe_SendEventUnsynced(t, roomID, b.Event{
-      Type: "com.example.dummy",
-      StateKey: ptr(fmt.Sprintf("%d", i)),
-      Content: map[string]any{},
-    })
+		alice.Unsafe_SendEventUnsynced(t, roomID, b.Event{
+			Type:     "com.example.dummy",
+			StateKey: ptr(fmt.Sprintf("%d", i)),
+			Content:  map[string]any{},
+		})
 	}
 
 	t.Log("Alice sends a batch of message events.")


### PR DESCRIPTION
Three things are happening here:

1) An environment variable is added to allow for non-colorized text to be output. This is so /usr/sbin/daemon can direct stdout to syslog without escaped control sequences:

    Apr 15 14:48:52 orla syncv3[41839]: ^[[90m14:48:52^[[0m ^[[32mINF^[[0m Poller: accumulated data ^[[36mdevice [events,changed,left,account]=^[[0m[0,0,0,0] ^[[36mdevice_id=^[[0mQRZLYYCRTO ^[[36mrooms [timeline,state,typing,receipts,invites]=^[[0m[0,0,0,0,0] ^[[36muser_id=^[[0m@doug:yutz.horph.com

I would have preferred a command-line switch instead of the env var but am following the existing pattern.

2) zerolog use is refactored. Since there really are no different types of log output and only minimal use of additional context, it makes sense to use zerolog's existing global logger. This simplifies things a bit both textually and cyclomatically and allows for central changes to the logger output based on the new env var.

3) A `go fmt ./...` changed a few very minor things.

### Pull Request Checklist

- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

