### PR TITLE
Clean the syncv3_snapshots table periodically 

### DIFF
--- a/cmd/syncv3/main.go
+++ b/cmd/syncv3/main.go
@@ -220,6 +220,7 @@ func main() {
 	})
 
 	go h2.StartV2Pollers()
+	go h2.Store.Cleaner(time.Hour)
 	if args[EnvOTLP] != "" {
 		h3 = otelhttp.NewHandler(h3, "Sync")
 	}


### PR DESCRIPTION
Also cleans the transaction table periodically.

Fixes https://github.com/matrix-org/sliding-sync/issues/372

On testing, this cuts db size to about 1/3 of its original size.