### PR TITLE
Add metadata-action so labels are generated

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,21 +35,18 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build main sliding sync image
-        if: github.ref_name == 'main'
-        id: docker_build_sliding_sync
-        uses: docker/build-push-action@v4
+      - name: Generate docker image tags
+        id: metadata
+        uses: docker/metadata-action@v5
         with:
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          context: .
-          platforms: ${{ env.PLATFORMS }}
-          push: true
+          images: |
+            name=ghcr.io/${{ github.repository_owner }}/${{ github.repository }}
           tags: |
-            ghcr.io/${{ env.GHCR_NAMESPACE }}/sliding-sync:main
+            ${{ github.ref_name == 'main' && 'type=raw,value=main' }}
+            ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && 'type=raw,value=latest' }}
+            type=raw,value=${{ github.ref_name }}
 
       - name: Build release Sliding Sync image
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         id: docker_build_sliding_sync_release
         uses: docker/build-push-action@v4
         with:
@@ -57,10 +54,9 @@ jobs:
           cache-to: type=gha,mode=max
           context: .
           platforms: ${{ env.PLATFORMS }}
-          push: true
-          tags: |
-            ghcr.io/${{ env.GHCR_NAMESPACE }}/sliding-sync:latest
-            ghcr.io/${{ env.GHCR_NAMESPACE }}/sliding-sync:${{ github.ref_name }}
+          push:  ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,9 +42,11 @@ jobs:
           images: |
             name=ghcr.io/${{ github.repository_owner }}/${{ github.repository }}
           tags: |
-            ${{ github.ref_name == 'main' && 'type=raw,value=main' }}
-            ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') && 'type=raw,value=latest' }}
-            type=raw,value=${{ github.ref_name }}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{raw}}
+            type=sha
+            type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
 
       - name: Build release Sliding Sync image
         id: docker_build_sliding_sync_release
@@ -54,7 +56,7 @@ jobs:
           cache-to: type=gha,mode=max
           context: .
           platforms: ${{ env.PLATFORMS }}
-          push:  ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+          push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
 


### PR DESCRIPTION
I use renovate to make sure my deployed apps are up to date. (https://github.com/halkeye/home-k8s/pull/116) and according to the [documentation](https://docs.renovatebot.com/modules/datasource/docker/) if the source docker label is set, it'll actually pull in the release notes.

I checked the latest release, and it doesn't seem to have the labels (or any labels) set, so using the pre-existing github action should populate all the nice metadata.

regctl image config --format '{{ jsonPretty .Config.Labels }}' ghcr.io/matrix-org/sliding-sync 	
null

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

