### PR TITLE
Ensure device list updates are robust to race conditions and network failures

### DIFF
--- a/state/device_data_table.go
+++ b/state/device_data_table.go
@@ -70,6 +70,9 @@ func (t *DeviceDataTable) Select(userID, deviceID string, swap bool) (result *in
 		if !swap {
 			return nil // don't swap
 		}
+		// the caller will only look at sent, so make sure what is new is now in sent
+		result.DeviceLists.Sent = result.DeviceLists.New
+
 		// swap over the fields
 		writeBack := *result
 		writeBack.DeviceLists.Sent = result.DeviceLists.New

--- a/state/device_data_table.go
+++ b/state/device_data_table.go
@@ -46,7 +46,7 @@ func NewDeviceDataTable(db *sqlx.DB) *DeviceDataTable {
 func (t *DeviceDataTable) Select(userID, deviceID string, swap bool) (result *internal.DeviceData, err error) {
 	err = sqlutil.WithTransaction(t.db, func(txn *sqlx.Tx) error {
 		var row DeviceDataRow
-		err = txn.Get(&row, `SELECT data FROM syncv3_device_data WHERE user_id=$1 AND device_id=$2`, userID, deviceID)
+		err = txn.Get(&row, `SELECT data FROM syncv3_device_data WHERE user_id=$1 AND device_id=$2 FOR UPDATE`, userID, deviceID)
 		if err != nil {
 			if err == sql.ErrNoRows {
 				// if there is no device data for this user, it's not an error.
@@ -104,7 +104,7 @@ func (t *DeviceDataTable) Upsert(dd *internal.DeviceData) (err error) {
 	err = sqlutil.WithTransaction(t.db, func(txn *sqlx.Tx) error {
 		// select what already exists
 		var row DeviceDataRow
-		err = txn.Get(&row, `SELECT data FROM syncv3_device_data WHERE user_id=$1 AND device_id=$2`, dd.UserID, dd.DeviceID)
+		err = txn.Get(&row, `SELECT data FROM syncv3_device_data WHERE user_id=$1 AND device_id=$2 FOR UPDATE`, dd.UserID, dd.DeviceID)
 		if err != nil && err != sql.ErrNoRows {
 			return err
 		}


### PR DESCRIPTION
Fixes #430

This does two things:
 - Fix a hypothetical race condition which could cause a lost update _at insert time_ (due to lack of `.. FOR UPDATE`)
 - Fix an issue which will cause lost device list updates if the response containing the update is A) lost and B) the client starts a new connection for whatever reason e.g timed out, full buffer, server restart.

This adds a regression test and refactors the unit tests to be testing the correct semantics.

History on this is:
 - the original impl worked but was confusing
 - dmr refactored it in https://github.com/matrix-org/sliding-sync/commit/740c14cabcf793e26d9a9b5ab51b31b258760364 but did introduce a bug. The `result` previously had the `New` items put into `Sent` (the original intent) but now we were copying `result` to `writeBack` and _then_ swapping_ `New` to `Sent`. As the caller only looks in `Sent`, it won't see any device list updates. This would fix itself on the _next request_ because we then return `Sent` confusingly. However, the semantics are like this to guard against network failures, and since this refactor specific network failures would drop the update.
 - tests got written using the buggy code as a guide https://github.com/matrix-org/sliding-sync/commit/1fe920d1b68485b7e71111b0d64bfb1b25b9ff23

I found this out when trying to fix [this test](https://github.com/matrix-org/complement-crypto/actions/runs/8999628143/job/24722166536?pr=50#step:15:3006) in complement crypto, which is sensitive to how quickly the device list update will be delivered to the EX client. Hence me finding the bug and fixing it.

This is effectively a UTD cause for the purposes of https://github.com/element-hq/element-meta/issues/245 because it meant EX clients may miss a device list update, causing EX clients to fail to encrypt for newly logged in devices (just like that failing complement crypto test).