### PR TITLE
Optimize getting the latest events in each room

### DIFF
--- a/state/event_table.go
+++ b/state/event_table.go
@@ -312,14 +312,35 @@ func (t *EventTable) UpdateBeforeSnapshotID(txn *sqlx.Tx, eventNID, snapID, repl
 	return err
 }
 
-// query the latest events in each of the room IDs given, using highestNID as the highest event.
+// LatestEventInRooms queries the latest events in each of the room IDs given, using highestNID as the highest event.
+//
+// The following query does:
+//
+//  1. Create a list of the passed in roomIDs (`room_ids` CTE)
+//  2. Fetches the highest event_nid before or equal to $2 for each room in room_ids (`max_ev_nid` CTE)
+//  3. Fetches the latest events for each room using the data provided from room_ids and max_ev_nid (the `evs` LATERAL)
 func (t *EventTable) LatestEventInRooms(txn *sqlx.Tx, roomIDs []string, highestNID int64) (events []Event, err error) {
-	// the position (event nid) may be for a random different room, so we need to find the highest nid <= this position for this room
 	err = txn.Select(
 		&events,
-		`SELECT event_nid, room_id, event_replaces_nid, before_state_snapshot_id, event_type, state_key, event FROM syncv3_events
-		WHERE event_nid IN (SELECT max(event_nid) FROM syncv3_events WHERE event_nid <= $1 AND room_id = ANY($2) GROUP BY room_id)`,
-		highestNID, pq.StringArray(roomIDs),
+		`
+WITH room_ids AS (
+    select unnest($1::text[]) AS room_id
+),
+max_ev_nid AS (
+	SELECT * 
+	FROM room_ids,
+    	LATERAL (
+        	SELECT max(event_nid) FROM syncv3_events e WHERE e.room_id = room_ids.room_id AND event_nid <= $2
+            ) AS x)
+SELECT evs.*
+FROM room_ids,
+     max_ev_nid,
+     LATERAL (
+         SELECT event_nid, room_id, event_replaces_nid, before_state_snapshot_id, event_type, state_key, event
+         FROM syncv3_events e
+         WHERE e.event_nid = max_ev_nid.max AND room_ids.room_id = e.room_id
+         ) AS evs`,
+		pq.StringArray(roomIDs), highestNID,
 	)
 	if err == sql.ErrNoRows {
 		err = nil


### PR DESCRIPTION
As mentioned internally, this significantly speeds up getting the latest event in each room provided.

Output of `EXPLAIN ANALYSE` 
```
 Planning Time: 0.408 ms
 Execution Time: 9158.038 ms
```
for the original with a cold cache

```
 Planning Time: 0.296 ms
 Execution Time: 101.383 ms
```
with a warm cache.

The optimized query with a cold cache:
```
 Planning Time: 1.902 ms
 Execution Time: 3.752 ms
```
and with a warm cache:
```
 Planning Time: 0.425 ms
 Execution Time: 0.131 ms
```