### PR TITLE
fix: urlencode since opaque string

### DIFF
--- a/sync2/client.go
+++ b/sync2/client.go
@@ -152,7 +152,7 @@ func (v *HTTPClient) createSyncURL(since string, isFirst, toDeviceOnly bool) str
 		qps += "timeout=30000"
 	}
 	if since != "" {
-		qps += "&since=" + since
+		qps += "&since=" + url.QueryEscape(since)
 	}
 
 	// Set presence to offline, this potentially reduces CPU load on upstream homeservers

--- a/sync2/client_test.go
+++ b/sync2/client_test.go
@@ -65,6 +65,12 @@ func TestSyncURL(t *testing.T) {
 			toDeviceOnly: true,
 			wantURL:      wantBaseURL + `?timeout=0&since=112233&set_presence=offline&filter=` + url.QueryEscape(`{"presence":{"not_types":["*"]},"room":{"rooms":[],"timeline":{"limit":50}}}`),
 		},
+		{
+			since:        "112233#145",
+			isFirst:      true,
+			toDeviceOnly: true,
+			wantURL:      wantBaseURL + `?timeout=0&since=112233%23145&set_presence=offline&filter=` + url.QueryEscape(`{"presence":{"not_types":["*"]},"room":{"rooms":[],"timeline":{"limit":50}}}`),
+		},
 	}
 	for i, tc := range testCases {
 		gotURL := client.createSyncURL(tc.since, tc.isFirst, tc.toDeviceOnly)


### PR DESCRIPTION
Since/next batch is an opaque string and might need to be urlencoded before being sent to the server.

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

