### PR TITLE
Update Landing.md - add info on how to use `extra_well_known_client_content` in `homeserver.yaml`

### DIFF
--- a/docs/Landing.md
+++ b/docs/Landing.md
@@ -4,12 +4,18 @@ Welcome intrepid Matrix explorer. You've landed on this page because you're tryi
 
 - Configure Postgres and install a sliding sync proxy as described in the [docs](https://github.com/matrix-org/sliding-sync).
 - Advertise the proxy by configuring an [`org.matrix.msc3575.proxy`](https://github.com/matrix-org/matrix-spec-proposals/blob/kegan/sync-v3/proposals/3575-sync.md#unstable-prefix) property in the server's `/.well-known/matrix/client` config:
-```
+```json
 {
     "org.matrix.msc3575.proxy": {
         "url": "https://slidingsync.proxy.url.here"
     }
 }
+```
+You can do this by adding the following to your homeserver.yaml:
+```yaml
+extra_well_known_client_content:
+  "org.matrix.msc3575.proxy":
+    "url": "https://slidingsync.proxy.url.here"
 ```
 
 Once these steps are complete you will be able to continue on your journey of exploring the very latest that Matrix has to offer!


### PR DESCRIPTION
# Description

Adds a small bit about how to use `extra_well_known_client_content` in homeserver.yaml to add `org.matrix.msc3575.proxy` to the json for well-known and adds syntax highlighting for the json code block.

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

