### PR TITLE
Add support for a JSON configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ SYNCV3_LOG_LEVEL     Default: info. The level of verbosity for messages logged. 
 SYNCV3_MAX_DB_CONN   Default: unset. Max database connections to use when communicating with postgres. Unset or 0 means no limit.
 ```
 
+These settings can also be specified on a JSON file which can then be passed to `syncv3` through the `-conf` flag. The JSON keys are the same as the environment
+variables; values must be specified as strings (i.e. they must be quoted). Bear in mind the settings specified as environment variables will override those
+defined through the configuration file.
+
 It is easiest to host the proxy on a separate hostname than the Matrix server, though it is possible to use the same hostname by forwarding the used endpoints.
 
 In both cases, the path `https://example.com/.well-known/matrix/client` must return a JSON with at least the following contents:

--- a/cmd/syncv3/main.go
+++ b/cmd/syncv3/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -32,6 +33,7 @@ const version = "0.99.18"
 
 var (
 	flags = flag.NewFlagSet("goose", flag.ExitOnError)
+	flagConf = flag.String("conf", "", "path to an optional configuration file.")
 )
 
 const (
@@ -87,6 +89,25 @@ func defaulting(in, dft string) string {
 	return in
 }
 
+func readConf(filePath string) (map[string]string, error) {
+	conf := map[string]string{}
+
+	if filePath == "" {
+		return conf, nil
+	}
+
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return conf, err
+	}
+
+	if err := json.Unmarshal(content, &conf); err != nil {
+		return conf, err
+	}
+
+	return conf, nil
+}
+
 func main() {
 	fmt.Printf("Sync v3 [%s] (%s)\n", version, GitCommit)
 	sync2.ProxyVersion = version
@@ -97,25 +118,31 @@ func main() {
 		return
 	}
 
+	flag.Parse()
+	confArgs, err := readConf(*flagConf)
+	if err != nil {
+		log.Fatalf("failed to read configuration file: %v\n", err)
+	}
+
 	args := map[string]string{
-		EnvServer:                 os.Getenv(EnvServer),
-		EnvDB:                     os.Getenv(EnvDB),
-		EnvSecret:                 os.Getenv(EnvSecret),
-		EnvBindAddr:               defaulting(os.Getenv(EnvBindAddr), "0.0.0.0:8008"),
-		EnvTLSCert:                os.Getenv(EnvTLSCert),
-		EnvTLSKey:                 os.Getenv(EnvTLSKey),
-		EnvPPROF:                  os.Getenv(EnvPPROF),
-		EnvPrometheus:             os.Getenv(EnvPrometheus),
-		EnvDebug:                  os.Getenv(EnvDebug),
-		EnvOTLP:                   os.Getenv(EnvOTLP),
-		EnvOTLPUsername:           os.Getenv(EnvOTLPUsername),
-		EnvOTLPPassword:           os.Getenv(EnvOTLPPassword),
-		EnvSentryDsn:              os.Getenv(EnvSentryDsn),
-		EnvLogLevel:               os.Getenv(EnvLogLevel),
-		EnvMaxConns:               defaulting(os.Getenv(EnvMaxConns), "0"),
-		EnvIdleTimeoutSecs:        defaulting(os.Getenv(EnvIdleTimeoutSecs), "3600"),
-		EnvHTTPTimeoutSecs:        defaulting(os.Getenv(EnvHTTPTimeoutSecs), "300"),
-		EnvHTTPInitialTimeoutSecs: defaulting(os.Getenv(EnvHTTPInitialTimeoutSecs), "1800"),
+		EnvServer:                 defaulting(os.Getenv(EnvServer), confArgs[EnvServer]),
+		EnvDB:                     defaulting(os.Getenv(EnvDB), confArgs[EnvDB]),
+		EnvSecret:                 defaulting(os.Getenv(EnvSecret), confArgs[EnvSecret]),
+		EnvBindAddr:               defaulting(os.Getenv(EnvBindAddr), defaulting(confArgs[EnvBindAddr], "0.0.0.0:8008")),
+		EnvTLSCert:                defaulting(os.Getenv(EnvTLSCert), confArgs[EnvTLSCert]),
+		EnvTLSKey:                 defaulting(os.Getenv(EnvTLSKey), confArgs[EnvTLSKey]),
+		EnvPPROF:                  defaulting(os.Getenv(EnvPPROF), confArgs[EnvPPROF]),
+		EnvPrometheus:             defaulting(os.Getenv(EnvPrometheus), confArgs[EnvPrometheus]),
+		EnvDebug:                  defaulting(os.Getenv(EnvDebug), confArgs[EnvDebug]),
+		EnvOTLP:                   defaulting(os.Getenv(EnvOTLP), confArgs[EnvOTLP]),
+		EnvOTLPUsername:           defaulting(os.Getenv(EnvOTLPUsername), confArgs[EnvOTLPUsername]),
+		EnvOTLPPassword:           defaulting(os.Getenv(EnvOTLPPassword), confArgs[EnvOTLPPassword]),
+		EnvSentryDsn:              defaulting(os.Getenv(EnvSentryDsn), confArgs[EnvSentryDsn]),
+		EnvLogLevel:               defaulting(os.Getenv(EnvLogLevel), confArgs[EnvLogLevel]),
+		EnvMaxConns:               defaulting(os.Getenv(EnvMaxConns), defaulting(confArgs[EnvMaxConns], "0")),
+		EnvIdleTimeoutSecs:        defaulting(os.Getenv(EnvIdleTimeoutSecs), defaulting(confArgs[EnvIdleTimeoutSecs], "3600")),
+		EnvHTTPTimeoutSecs:        defaulting(os.Getenv(EnvHTTPTimeoutSecs), defaulting(confArgs[EnvHTTPTimeoutSecs], "300")),
+		EnvHTTPInitialTimeoutSecs: defaulting(os.Getenv(EnvHTTPInitialTimeoutSecs), defaulting(confArgs[EnvHTTPInitialTimeoutSecs], "1800")),
 	}
 	requiredEnvVars := []string{EnvServer, EnvDB, EnvSecret, EnvBindAddr}
 	for _, requiredEnvVar := range requiredEnvVars {


### PR DESCRIPTION
This PR strives to add support for specifying the configuration options through a file. This PR is motivated by the discussion on #415.

In order to keep changes as smooth as possible we have chosen to leverage the name of the existing environment variables as the JSON keys. We have also chosen JSON so as to avoid delving into parsing logic; besides, JSON encoding/decoding are part of the standard library.

The path to the configuration file is to be passed through the `-conf` flag.

In order to remain backwards-compatible, environment variables will always override settings specified on the JSON file. The default values for settings will also be honoured.

At any rate, we're more than happy to change anything that might be needed.

Thanks a ton for your time!

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)