### PR TITLE
fix Incorrect conversion between integer types

### DIFF
--- a/sync3/handler/handler.go
+++ b/sync3/handler/handler.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -288,7 +289,12 @@ func (h *SyncLiveHandler) serve(w http.ResponseWriter, req *http.Request) error 
 		if herr != nil {
 			return herr
 		}
-		timeout = int(timeout64)
+		// Bounds check before converting int64 to int
+		if timeout64 < 0 || timeout64 > int64(math.MaxInt) {
+			timeout = sync3.DefaultTimeoutMSecs
+		} else {
+			timeout = int(timeout64)
+		}
 	}
 
 	requestBody.SetTimeoutMSecs(timeout)


### PR DESCRIPTION
The correct way to fix this issue is to ensure that, before converting from `int64` to `int`, the value is in the valid range for the local platform's `int` size. In Go, the maximum and minimum values for `int` can be obtained from the `math` package: `math.MaxInt` and `math.MinInt`. Therefore, before performing `timeout = int(timeout64)`, there should be a check confirming that `timeout64` is within this range. If the value is out of bounds or negative, fall back to a safe default (e.g., `sync3.DefaultTimeoutMSecs`). The best practice is also to reject negative timeouts, either by enforcing positive values or using zero if desired. All changes will be within sync3/handler/handler.go at lines 291 and around.

Required: Add an import for `math` only if not present (it is not present in the current snippet, so add it). Amend lines in the relevant handler function to include upper/lower bounds checks.

#### References
[Integer overflow](https://en.wikipedia.org/wiki/Integer_overflow)
[Integer overflow](https://golang.org/ref/spec#Integer_overflow)
[strconv.Atoi](https://golang.org/pkg/strconv/#Atoi)
[strconv.ParseInt](https://golang.org/pkg/strconv/#ParseInt)
[strconv.ParseUint](https://golang.org/pkg/strconv/#ParseUint)

### Pull Request Checklist

- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)

